### PR TITLE
Bootstrap the CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,37 @@
+name: Rust CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rust-version: stable
+
+      - name: Run tests on the root project
+        run: cargo test --workspace
+
+      - name: Run tests on example crates
+        run: |
+          for example in examples/*/; do
+            if [ -f "$example/Cargo.toml" ]; then
+              echo "Running tests for $example"
+              cd $example && cargo test && cd -
+            fi
+          done


### PR DESCRIPTION
This PR addresses and closes issue #4 by bootstrapping CI for the repository. It adds a GitHub Actions workflow that:

- Runs cargo test on the root project.

- Runs cargo test on all example crates.

Is triggered on:

- Every push to the main branch.

- Every pull request targeting the main branch.

And runs on:
- Ubuntu
- MacOs
