### PR TITLE
🔧 ci: add code coverage visualization

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -19,6 +19,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry, ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -32,6 +40,20 @@ jobs:
           for example in examples/*/; do
             if [ -f "$example/Cargo.toml" ]; then
               echo "Running tests for $example"
-              cd $example && cargo test && cd -
+              (cd $example && cargo test)
             fi
           done
+
+      - name: Install cargo-tarpaulin for coverage
+        run: cargo install cargo-tarpaulin
+
+      - name: Run coverage with cargo-tarpaulin
+        run: cargo tarpaulin --out Xml
+        if: success()
+
+      - name: Upload coverage results to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          file: ./target/debug/deps/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+        if: success()

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ tower-stratum
 </h1>
 
 <p align="center">
+  <a href="https://codecov.io/gh/plebhash/tower-stratum" > 
+    <img src="https://codecov.io/gh/plebhash/tower-stratum/graph/badge.svg?token=6ME38GTAIP"/> 
+  </a>
+</p>
+<p align="center">
 🦀 Tower middleware for Bitcoin mining over <a href="https://github.com/stratum-mining/stratum">Stratum V2 Reference Implementation</a> ⛏️
 </p>
 
@@ -163,6 +168,6 @@ let response = client.call(RequestToSv2Client::SendRequestToSiblingServerService
 
 ![](./docs/SendRequestToSiblingServerService.png)
 
-# Licence
+# License
 
 [`MIT`](LICENSE)


### PR DESCRIPTION
**Closes #3**

- Adds **Tarpaulin** for computing code coverage.
- Configures **Codecov** integration to automatically upload coverage results.
- Includes a **coverage badge** in the README to display the current code coverage status.
- Fixes a minor **typographical error** in the README.
- Enhances build performance by adding a **cache layer** for Rust dependencies.

**Follow-up:**
- After merging, you'll need to configure Codecov for the main repository. Detailed steps for setup are provided in the PR comments.