### PR TITLE
Add new example regarding the SiblingIO feature

### DIFF
--- a/examples/sibling-io-communication/Cargo.toml
+++ b/examples/sibling-io-communication/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sibling-io-communication"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tower-stratum = { path = "../.." }
+tokio = { version = "1", features = ["full"] }
+anyhow = "1.0.98"
+tracing = "0.1.41"
+roles_logic_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
+hex = "0.4.3"
+tracing-subscriber = "0.3.19"
+integration_tests_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
+
+[dev-dependencies]
+const_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
+binary_codec_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }

--- a/examples/sibling-io-communication/src/configs.rs
+++ b/examples/sibling-io-communication/src/configs.rs
@@ -1,0 +1,66 @@
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
+
+use tower_stratum::{
+    client::service::config::{Sv2ClientServiceConfig, Sv2ClientServiceTemplateDistributionConfig},
+    key_utils::{Secp256k1PublicKey, Secp256k1SecretKey},
+    server::service::config::{
+        Sv2ServerServiceConfig, Sv2ServerServiceMiningConfig, Sv2ServerTcpConfig,
+    },
+};
+
+pub struct MyConfig {
+    pub server_config: Sv2ServerServiceConfig,
+    pub client_config: Sv2ClientServiceConfig,
+}
+
+impl MyConfig {
+    pub fn new() -> Self {
+        let server_config = Sv2ServerServiceConfig {
+            min_supported_version: 2,
+            max_supported_version: 2,
+            inactivity_limit: 3600,
+            tcp_config: Sv2ServerTcpConfig {
+                listen_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3333),
+                pub_key: Secp256k1PublicKey::from_str(
+                    "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72",
+                )
+                .unwrap(),
+                priv_key: Secp256k1SecretKey::from_str(
+                    "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n",
+                )
+                .unwrap(),
+                cert_validity: 3600,
+            },
+            mining_config: Some(Sv2ServerServiceMiningConfig {
+                supported_flags: 0b0101,
+            }),
+            job_declaration_config: None,
+            template_distribution_config: None,
+        };
+
+        let client_config = Sv2ClientServiceConfig {
+            min_supported_version: 2,
+            max_supported_version: 2,
+            endpoint_host: None,
+            endpoint_port: None,
+            vendor: None,
+            hardware_version: None,
+            device_id: None,
+            firmware: None,
+            mining_config: None,
+            job_declaration_config: None,
+            template_distribution_config: Some(Sv2ClientServiceTemplateDistributionConfig {
+                server_addr: SocketAddr::from_str("127.0.0.1:8442").unwrap(),
+                auth_pk: None,
+                coinbase_output_constraints: (1, 1),
+            }),
+        };
+        Self {
+            server_config,
+            client_config,
+        }
+    }
+}

--- a/examples/sibling-io-communication/src/main.rs
+++ b/examples/sibling-io-communication/src/main.rs
@@ -1,0 +1,350 @@
+use anyhow::Ok;
+use integration_tests_sv2::start_template_provider;
+use mining_server_handler::MyMiningServerHandler;
+use template_distribution_handler::MyTemplateDistributionHandler;
+use tower_stratum::{
+    client::service::{
+        Sv2ClientService, request::RequestToSv2Client,
+        subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService,
+    },
+    server::service::Sv2ServerService,
+    tower::Service,
+};
+use tracing::info;
+mod configs;
+mod mining_server_handler;
+mod template_distribution_handler;
+
+// This example demonstrates how to use the SiblingIO feature described in the README.
+// The goal is to spawn three services:
+// 1. A Template Provider that sends new templates.
+// 2. A client that connects to the Template Provider and receives these templates.
+// 3. A server that receives the templates from the client via SiblingIO.
+//
+// The `template_distribution_handler.rs` file sends templates to `mining_server_handler.rs` using SiblingIO.
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+    let mut config = configs::MyConfig::new();
+
+    // Create a Template Provider that will accept connections from the TemplateDistributionClientHandler.
+    // This simulates a Template Provider used to send templates.
+    // In a real-world scenario, this would be a separate process or service.
+    // Typically, a Bitcoin node with SV2 support would be used.
+    // For this example, we use a fork maintained by Sjors: https://github.com/Sjors/bitcoin/releases.
+    let (_tp, tp_address) = start_template_provider(None);
+
+    // Since the Template Provider created by `start_template_provider` listens on a dynamic port,
+    // we need to update our configuration with the correct address.
+    config
+        .client_config
+        .template_distribution_config
+        .as_mut()
+        .unwrap()
+        .server_addr = tp_address;
+
+    info!("Template Provider address: {:?}", tp_address);
+
+    // Initialize the handlers for TemplateDistribution and MiningServer.
+    let tdc_handler = MyTemplateDistributionHandler::default();
+    let mining_handler = MyMiningServerHandler::default();
+
+    // Create the Sv2ServerService and Sv2ClientService using the handlers.
+
+    // The Sv2ServerService returns a [`Sv2SiblingServerServiceIo`] object.
+    // This object is used to send and receive requests to/from a sibling [`tower_stratum::client::service::Sv2ClientService`].
+    let (
+        mut server_service,
+        sibling_server_io, // <----- SiblingIO is created here.
+    ) = Sv2ServerService::new_with_sibling_io(config.server_config, mining_handler).unwrap();
+
+    // Create the client service that communicates with the server using the `sibling_server_io` created above.
+    let client_config = config.client_config.clone();
+    let mut client_service = Sv2ClientService::new_with_sibling_io(
+        client_config,
+        tdc_handler,
+        sibling_server_io, // <----- SiblingIO is passed here.
+    )?;
+
+    // Start the server and client services.
+    server_service.start().await?;
+    client_service.start().await?;
+
+    // Once the connection is established, set the coinbase constraints with the Template Provider.
+    // This step is necessary to start receiving new templates.
+    client_service
+        .call(RequestToSv2Client::TemplateDistributionTrigger(
+            RequestToSv2TemplateDistributionClientService::SetCoinbaseOutputConstraints(
+                config
+                    .client_config
+                    .template_distribution_config
+                    .as_ref()
+                    .unwrap()
+                    .coinbase_output_constraints
+                    .0
+                    .clone(),
+                config
+                    .client_config
+                    .template_distribution_config
+                    .as_ref()
+                    .unwrap()
+                    .coinbase_output_constraints
+                    .1
+                    .clone(),
+            ),
+        ))
+        .await
+        .unwrap();
+
+    // At this point, the client starts receiving new templates from the Template Provider.
+    // These templates are sent to the MiningServer via SiblingIO.
+    // Check the handlers to see how the messages are passed.
+    // Logs are printed in the handlers for debugging and monitoring.
+
+    // Wait for a Ctrl-C signal to terminate the application.
+    tokio::signal::ctrl_c().await?;
+
+    // Shutdown the server and client services gracefully.
+    server_service.shutdown().await;
+    client_service.shutdown().await;
+    info!("Server and Client services shutdown");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, str::FromStr};
+
+    use const_sv2::MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS;
+    use integration_tests_sv2::{sniffer::MessageDirection, start_sniffer};
+    use roles_logic_sv2::template_distribution_sv2::{NewTemplate, SetNewPrevHash};
+    use tower_stratum::{
+        client::service::{request::RequestToSv2ClientError, response::ResponseFromSv2Client},
+        server::service::{
+            request::RequestToSv2Server, subprotocols::mining::request::RequestToSv2MiningServer,
+        },
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_sibling_io() {
+        // Initialize the configuration for the test.
+        let mut config = configs::MyConfig::new();
+
+        // Start a Template Provider that simulates a Bitcoin node with SV2 support.
+        let (_tp, tp_address) = start_template_provider(None);
+
+        // Start a sniffer to intercept messages between the client and the Template Provider.
+        let (tp_sniffer, tp_sniffer_addr) =
+            start_sniffer("".to_string(), tp_address, false, None).await;
+
+        // Update the client configuration to use the sniffer's address.
+        config
+            .client_config
+            .template_distribution_config
+            .as_mut()
+            .unwrap()
+            .server_addr = tp_sniffer_addr;
+
+        config.server_config.tcp_config.listen_address =
+            SocketAddr::from_str("127.0.0.1:0").unwrap();
+
+        // Allow some time for the sniffer to initialize.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Initialize the handlers for TemplateDistribution and MiningServer.
+        let tdc_handler = MyTemplateDistributionHandler::default();
+        let mining_handler = MyMiningServerHandler::default();
+
+        // Create the Sv2ServerService and its sibling IO for communication with the client.
+        let (
+            mut server_service,
+            sibling_server_io, // SiblingIO is created here.
+        ) = Sv2ServerService::new_with_sibling_io(config.server_config, mining_handler).unwrap();
+
+        // Create the Sv2ClientService and connect it to the server using the sibling IO.
+        let client_config = config.client_config.clone();
+        let mut client_service =
+            Sv2ClientService::new_with_sibling_io(client_config, tdc_handler, sibling_server_io)
+                .unwrap();
+
+        // Start the server and client services.
+        server_service.start().await.unwrap();
+        client_service.start().await.unwrap();
+
+        // Trigger the Template Provider to set coinbase output constraints.
+        client_service
+            .call(RequestToSv2Client::TemplateDistributionTrigger(
+                RequestToSv2TemplateDistributionClientService::SetCoinbaseOutputConstraints(
+                    config
+                        .client_config
+                        .template_distribution_config
+                        .as_ref()
+                        .unwrap()
+                        .coinbase_output_constraints
+                        .0
+                        .clone(),
+                    config
+                        .client_config
+                        .template_distribution_config
+                        .as_ref()
+                        .unwrap()
+                        .coinbase_output_constraints
+                        .1
+                        .clone(),
+                ),
+            ))
+            .await
+            .unwrap();
+
+        // Wait for the sniffer to detect the coinbase output constraints message.
+        tp_sniffer
+            .wait_for_message_type(
+                MessageDirection::ToUpstream,
+                MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS,
+            )
+            .await;
+
+        // Create a dummy NewTemplate message to simulate a new mining template.
+        let new_template = NewTemplate {
+            template_id: 0,
+            future_template: false,
+            version: 0,
+            coinbase_tx_version: 0,
+            coinbase_prefix: binary_codec_sv2::B0255::Owned(hex::decode("00").unwrap().to_vec()),
+            coinbase_tx_input_sequence: 0,
+            coinbase_tx_value_remaining: 0,
+            coinbase_tx_outputs_count: 0,
+            coinbase_tx_outputs: binary_codec_sv2::B064K::Owned(
+                hex::decode("00").unwrap().to_vec(),
+            ),
+            coinbase_tx_locktime: 0,
+            merkle_path: binary_codec_sv2::Seq0255::new(Vec::new()).unwrap(),
+        };
+
+        // Send the NewTemplate message to the sibling server and verify the response.
+        let new_template_response = client_service
+            .call(RequestToSv2Client::SendRequestToSiblingServerService(
+                Box::new(RequestToSv2Server::MiningTrigger(
+                    RequestToSv2MiningServer::NewTemplate(new_template),
+                )),
+            ))
+            .await;
+
+        // Assert that the response was sent to the sibling server.
+        assert!(matches!(
+            new_template_response.as_ref().unwrap(),
+            ResponseFromSv2Client::SentRequestToSiblingServerService(
+                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::NewTemplate(_))
+            )
+        ));
+
+        // Create a dummy SetNewPrevHash message to simulate a new previous hash.
+        let new_prev_hash = SetNewPrevHash {
+            template_id: 0,
+            prev_hash: binary_codec_sv2::U256::Owned(hex::decode("00").unwrap().to_vec()),
+            header_timestamp: 0,
+            n_bits: 0,
+            target: binary_codec_sv2::U256::Owned(hex::decode("00").unwrap().to_vec()),
+        };
+
+        // Send the SetNewPrevHash message to the sibling server and verify the response.
+        let new_prev_hash_response = client_service
+            .call(RequestToSv2Client::SendRequestToSiblingServerService(
+                Box::new(RequestToSv2Server::MiningTrigger(
+                    RequestToSv2MiningServer::SetNewPrevHash(new_prev_hash),
+                )),
+            ))
+            .await
+            .unwrap();
+
+        // Assert that the response from the MiningServerHandler is received.
+        assert!(matches!(
+            new_prev_hash_response,
+            ResponseFromSv2Client::SentRequestToSiblingServerService(
+                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::SetNewPrevHash(_))
+            )
+        ));
+
+        // Shutdown the server and client services gracefully.
+        server_service.shutdown().await;
+        client_service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_sibling_io_with_wrong_constructor() {
+        // Initialize the configuration for the test.
+        let mut config = configs::MyConfig::new();
+
+        // Start a Template Provider that simulates a Bitcoin node with SV2 support.
+        let (_tp, tp_address) = start_template_provider(None);
+
+        // Update the client configuration to use the sniffer's address.
+        config
+            .client_config
+            .template_distribution_config
+            .as_mut()
+            .unwrap()
+            .server_addr = tp_address;
+
+        config.server_config.tcp_config.listen_address =
+            SocketAddr::from_str("127.0.0.1:0").unwrap();
+
+        // Allow some time for the sniffer to initialize.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Initialize the handlers for TemplateDistribution and MiningServer.
+        let tdc_handler = MyTemplateDistributionHandler::default();
+        let mining_handler = MyMiningServerHandler::default();
+
+        // Create the Sv2ServerService with a wrong constructor.
+        let mut server_service =
+            Sv2ServerService::new(config.server_config, mining_handler).unwrap();
+        // Create the Sv2ClientService with a wrong constructor.
+        let mut client_service = Sv2ClientService::new(config.client_config, tdc_handler).unwrap();
+
+        // Start the server and client services.
+        server_service.start().await.unwrap();
+        client_service.start().await.unwrap();
+
+        // Create a dummy NewTemplate message to simulate a new mining template.
+        let new_template = NewTemplate {
+            template_id: 0,
+            future_template: false,
+            version: 0,
+            coinbase_tx_version: 0,
+            coinbase_prefix: binary_codec_sv2::B0255::Owned(hex::decode("00").unwrap().to_vec()),
+            coinbase_tx_input_sequence: 0,
+            coinbase_tx_value_remaining: 0,
+            coinbase_tx_outputs_count: 0,
+            coinbase_tx_outputs: binary_codec_sv2::B064K::Owned(
+                hex::decode("00").unwrap().to_vec(),
+            ),
+            coinbase_tx_locktime: 0,
+            merkle_path: binary_codec_sv2::Seq0255::new(Vec::new()).unwrap(),
+        };
+
+        // Send the NewTemplate message to the sibling server and verify the response.
+        let new_template_response = client_service
+            .call(RequestToSv2Client::SendRequestToSiblingServerService(
+                Box::new(RequestToSv2Server::MiningTrigger(
+                    RequestToSv2MiningServer::NewTemplate(new_template),
+                )),
+            ))
+            .await;
+
+        // Assert that the error is of type RequestToSv2ClientError::NoSiblingServerServiceIo.
+        assert!(matches!(
+            new_template_response,
+            Err(RequestToSv2ClientError::NoSiblingServerServiceIo)
+        ));
+
+        // Shutdown the server and client services gracefully.
+        server_service.shutdown().await;
+        client_service.shutdown().await;
+    }
+}

--- a/examples/sibling-io-communication/src/mining_server_handler.rs
+++ b/examples/sibling-io-communication/src/mining_server_handler.rs
@@ -1,0 +1,121 @@
+use anyhow::Result;
+use roles_logic_sv2::mining_sv2::{
+    CloseChannel, OpenExtendedMiningChannel, OpenStandardMiningChannel, SetCustomMiningJob,
+    SubmitSharesExtended, SubmitSharesStandard, UpdateChannel,
+};
+use roles_logic_sv2::template_distribution_sv2::{NewTemplate, SetNewPrevHash};
+use tower_stratum::server::service::request::RequestToSv2ServerError;
+use tower_stratum::server::service::response::ResponseFromSv2Server;
+use tower_stratum::server::service::subprotocols::mining::handler::Sv2MiningServerHandler;
+
+use std::task::{Context, Poll};
+use tracing::info;
+
+#[derive(Debug, Clone, Default)]
+pub struct MyMiningServerHandler {
+    // You can add your custom fields here to store state or callbacks if needed.
+}
+
+impl Sv2MiningServerHandler for MyMiningServerHandler {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), RequestToSv2ServerError>> {
+        Poll::Ready(Ok(()))
+    }
+
+    async fn on_new_template(
+        &self,
+        m: NewTemplate<'static>,
+    ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
+        info!(
+            template_id = m.template_id,
+            "MiningServer: Received new template"
+        );
+
+        // Store the latest template ID for assertions in tests
+
+        Ok(ResponseFromSv2Server::ToDo)
+    }
+
+    async fn on_set_new_prev_hash(
+        &self,
+        m: SetNewPrevHash<'static>,
+    ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
+        info!(prev_hash = ?m.prev_hash, "MiningServer: Received new previous hash");
+        Ok(ResponseFromSv2Server::ToDo)
+    }
+
+    fn setup_connection_success_flags(&self) -> u32 {
+        0
+    }
+
+    async fn add_client(&mut self, client_id: u32, flags: u32) {
+        info!("adding client with id: {}, flags: {}", client_id, flags);
+    }
+
+    async fn remove_client(&mut self, client_id: u32) {
+        info!("removing client with id: {}", client_id);
+    }
+
+    async fn remove_all_clients(&mut self) {
+        info!("removing all clients");
+    }
+
+    async fn handle_open_standard_mining_channel(
+        &self,
+        _client_id: u32,
+        _m: OpenStandardMiningChannel<'static>,
+    ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
+        unimplemented!(
+            "MyMiningServerHandler does not implement handle_open_standard_mining_channel"
+        )
+    }
+
+    async fn handle_open_extended_mining_channel(
+        &self,
+        _client_id: u32,
+        _m: OpenExtendedMiningChannel<'static>,
+    ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
+        unimplemented!(
+            "MyMiningServerHandler does not implement handle_open_extended_mining_channel"
+        )
+    }
+
+    async fn handle_update_channel(
+        &self,
+        _client_id: u32,
+        _m: UpdateChannel<'static>,
+    ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
+        unimplemented!("MyMiningServerHandler does not implement handle_update_channel")
+    }
+
+    async fn handle_close_channel(
+        &self,
+        _client_id: u32,
+        _m: CloseChannel<'static>,
+    ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
+        unimplemented!("MyMiningServerHandler does not implement handle_close_channel")
+    }
+
+    async fn handle_submit_shares_standard(
+        &self,
+        _client_id: u32,
+        _m: SubmitSharesStandard,
+    ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
+        unimplemented!("MyMiningServerHandler does not implement handle_submit_shares_standard")
+    }
+
+    async fn handle_submit_shares_extended(
+        &self,
+        _client_id: u32,
+        _m: SubmitSharesExtended<'static>,
+    ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
+        unimplemented!("MyMiningServerHandler does not implement handle_submit_shares_extended")
+    }
+
+    async fn handle_set_custom_mining_job(
+        &self,
+        _client_id: u32,
+        _m: SetCustomMiningJob<'static>,
+    ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
+        unimplemented!("MyMiningServerHandler does not implement handle_set_custom_mining_job")
+    }
+}

--- a/examples/sibling-io-communication/src/template_distribution_handler.rs
+++ b/examples/sibling-io-communication/src/template_distribution_handler.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use roles_logic_sv2::template_distribution_sv2::{NewTemplate, SetNewPrevHash};
+
+use roles_logic_sv2::template_distribution_sv2::{
+    RequestTransactionDataError, RequestTransactionDataSuccess,
+};
+use std::task::{Context, Poll};
+use tower_stratum::client::service::request::{RequestToSv2Client, RequestToSv2ClientError};
+use tower_stratum::client::service::response::ResponseFromSv2Client;
+use tower_stratum::client::service::subprotocols::template_distribution::handler::Sv2TemplateDistributionClientHandler;
+use tower_stratum::server::service::request::RequestToSv2Server;
+use tower_stratum::server::service::subprotocols::mining::request::RequestToSv2MiningServer;
+use tracing::info;
+#[derive(Debug, Clone, Default)]
+pub struct MyTemplateDistributionHandler {
+    // Add fields here to store state or callbacks if needed.
+}
+
+/// Implements the `Sv2TemplateDistributionClientHandler` trait for `MyTemplateDistributionHandler`.
+/// This trait defines how the handler processes incoming template distribution events.
+impl Sv2TemplateDistributionClientHandler for MyTemplateDistributionHandler {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), RequestToSv2ClientError>> {
+        // Indicates that the handler is ready to process requests.
+        Poll::Ready(Ok(()))
+    }
+
+    async fn handle_new_template(
+        &self,
+        template: NewTemplate<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!(
+            template_id = template.template_id,
+            "TDC: Forwarding new template to MiningServer"
+        );
+
+        // This is where the SiblingIO mechanism is utilized.
+        // The new template is forwarded to the MiningServer using a sibling request.
+        // For more details on SiblingIO, refer to the following link:
+        // https://github.com/plebhash/tower-stratum/blob/de6d909bae4c85e19b75b20081b921efb6830d81/src/client/service/mod.rs#L774-L781
+        // SiblingIO works by recursively triggering requests. In this case, a new request of type
+        // `RequestToSv2Client::SendRequestToSiblingServerService` is created and dispatched to the MiningServer.
+        // The MiningServer, being a sibling server of the TDC Handler, processes the request accordingly.
+
+        let response = ResponseFromSv2Client::TriggerNewRequest(
+            RequestToSv2Client::SendRequestToSiblingServerService(Box::new(
+                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::NewTemplate(template)),
+            )),
+        );
+        Ok(response)
+    }
+
+    async fn handle_set_new_prev_hash(
+        &self,
+        prev_hash: SetNewPrevHash<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!(prev_hash = ?prev_hash, "MiningServer: Received new previous hash");
+
+        // Similar to `handle_new_template`, this forwards the new previous hash to the MiningServer.
+        let response = ResponseFromSv2Client::TriggerNewRequest(
+            RequestToSv2Client::SendRequestToSiblingServerService(Box::new(
+                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::SetNewPrevHash(
+                    prev_hash,
+                )),
+            )),
+        );
+        Ok(response)
+    }
+
+    async fn handle_request_transaction_data_success(
+        &self,
+        transaction_data: RequestTransactionDataSuccess<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!(
+            "received request transaction data success: {:?}",
+            transaction_data
+        );
+        Ok(ResponseFromSv2Client::Ok)
+    }
+
+    async fn handle_request_transaction_data_error(
+        &self,
+        error: RequestTransactionDataError<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received request transaction data error: {:?}", error);
+        Ok(ResponseFromSv2Client::Ok)
+    }
+}


### PR DESCRIPTION
Closes #13

This pull request adds a new example project, `sibling-io-communication`, showcasing how to use **SiblingIO** for inter-service communication.

The example demonstrates the transmission of `NewTemplate` and `SetNewPrevHash` messages from the **Template Distribution Handler** to the **Mining Server Handler**.

Additionally, tests have been included in to verify SiblingIO behavior, covering both correct and incorrect service initialization scenarios.
