### PR TITLE
add support for encrypted and unencrypted TCP connections based on config params

### DIFF
--- a/examples/mining-client-cpu-miner/src/client.rs
+++ b/examples/mining-client-cpu-miner/src/client.rs
@@ -37,6 +37,7 @@ impl MyMiningClient {
             }),
             job_declaration_config: None,
             template_distribution_config: None,
+            encrypted: true
         };
 
         let template_distribution_handler = NullSv2TemplateDistributionClientHandler;

--- a/examples/mining-server/src/server.rs
+++ b/examples/mining-server/src/server.rs
@@ -22,6 +22,7 @@ impl MyMiningServer {
             pub_key: config.pub_key,
             priv_key: config.priv_key,
             cert_validity: config.cert_validity,
+            encrypted: true,
         };
 
         let service_config = Sv2ServerServiceConfig {

--- a/examples/sibling-io-communication/src/configs.rs
+++ b/examples/sibling-io-communication/src/configs.rs
@@ -33,6 +33,7 @@ impl MyConfig {
                 )
                 .unwrap(),
                 cert_validity: 3600,
+                encrypted: true
             },
             mining_config: Some(Sv2ServerServiceMiningConfig {
                 supported_flags: 0b0101,
@@ -58,6 +59,7 @@ impl MyConfig {
                 coinbase_output_constraints: (1, 1),
                 setup_connection_flags: 0,
             }),
+            encrypted: true,
         };
         Self {
             server_config,

--- a/examples/template-distribution-client/src/client.rs
+++ b/examples/template-distribution-client/src/client.rs
@@ -40,6 +40,7 @@ impl MyTemplateDistributionClient {
                 auth_pk: config.auth_pk,
                 setup_connection_flags: 0, // no flags for setup_connection
             }),
+            encrypted: true,
         };
 
         // Create the handler instance

--- a/src/client/service/config.rs
+++ b/src/client/service/config.rs
@@ -27,6 +27,8 @@ pub struct Sv2ClientServiceConfig {
     pub job_declaration_config: Option<Sv2ClientServiceJobDeclarationConfig>,
     /// Configuration specific to the Template Distribution protocol
     pub template_distribution_config: Option<Sv2ClientServiceTemplateDistributionConfig>,
+    /// The TCP connection will be encrypted if this is set to true.
+    pub encrypted: bool,
 }
 
 impl Sv2ClientServiceConfig {

--- a/src/client/service/mod.rs
+++ b/src/client/service/mod.rs
@@ -11,7 +11,8 @@ use crate::client::service::subprotocols::template_distribution::handler::NullSv
 use crate::client::service::subprotocols::template_distribution::handler::Sv2TemplateDistributionClientHandler;
 use crate::client::service::subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService;
 use crate::client::service::subprotocols::template_distribution::response::ResponseToTemplateDistributionTrigger;
-use crate::client::tcp::encrypted::Sv2EncryptedTcpClient;
+use crate::client::tcp::Sv2TcpClient;
+
 use const_sv2::MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS;
 use const_sv2::MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL;
 use const_sv2::MESSAGE_TYPE_OPEN_STANDARD_MINING_CHANNEL;
@@ -57,9 +58,9 @@ where
     T: Sv2TemplateDistributionClientHandler + Clone + Send + Sync + 'static,
 {
     config: Sv2ClientServiceConfig,
-    mining_tcp_client: Arc<RwLock<Option<Sv2EncryptedTcpClient>>>,
-    job_declaration_tcp_client: Arc<RwLock<Option<Sv2EncryptedTcpClient>>>,
-    template_distribution_tcp_client: Arc<RwLock<Option<Sv2EncryptedTcpClient>>>,
+    mining_tcp_client: Arc<RwLock<Option<Sv2TcpClient>>>,
+    job_declaration_tcp_client: Arc<RwLock<Option<Sv2TcpClient>>>,
+    template_distribution_tcp_client: Arc<RwLock<Option<Sv2TcpClient>>>,
     mining_handler: M,
     // todo: add job_declaration_handler: J,
     template_distribution_handler: T,
@@ -298,13 +299,17 @@ where
                             protocol: Protocol::MiningProtocol,
                         }
                     })?;
-                    let tcp_client = Sv2EncryptedTcpClient::new(config.server_addr, config.auth_pk)
-                        .await
-                        .ok_or_else(|| {
-                            RequestToSv2ClientError::ConnectionError(
-                                "Failed to create TCP client".to_string(),
-                            )
-                        })?;
+                    let tcp_client = Sv2TcpClient::new(
+                        config.server_addr,
+                        self.config.encrypted,
+                        config.auth_pk,
+                    )
+                    .await
+                    .ok_or_else(|| {
+                        RequestToSv2ClientError::ConnectionError(
+                            "Failed to create TCP client".to_string(),
+                        )
+                    })?;
                     self.mining_tcp_client
                         .write()
                         .await
@@ -326,13 +331,17 @@ where
                             protocol: Protocol::JobDeclarationProtocol,
                         }
                     })?;
-                    let tcp_client = Sv2EncryptedTcpClient::new(config.server_addr, config.auth_pk)
-                        .await
-                        .ok_or_else(|| {
-                            RequestToSv2ClientError::ConnectionError(
-                                "Failed to create TCP client".to_string(),
-                            )
-                        })?;
+                    let tcp_client = Sv2TcpClient::new(
+                        config.server_addr,
+                        self.config.encrypted,
+                        config.auth_pk,
+                    )
+                    .await
+                    .ok_or_else(|| {
+                        RequestToSv2ClientError::ConnectionError(
+                            "Failed to create TCP client".to_string(),
+                        )
+                    })?;
                     self.job_declaration_tcp_client
                         .write()
                         .await
@@ -356,13 +365,17 @@ where
                         .ok_or_else(|| RequestToSv2ClientError::UnsupportedProtocol {
                             protocol: Protocol::TemplateDistributionProtocol,
                         })?;
-                    let tcp_client = Sv2EncryptedTcpClient::new(config.server_addr, config.auth_pk)
-                        .await
-                        .ok_or_else(|| {
-                            RequestToSv2ClientError::ConnectionError(
-                                "Failed to create TCP client".to_string(),
-                            )
-                        })?;
+                    let tcp_client = Sv2TcpClient::new(
+                        config.server_addr,
+                        self.config.encrypted,
+                        config.auth_pk,
+                    )
+                    .await
+                    .ok_or_else(|| {
+                        RequestToSv2ClientError::ConnectionError(
+                            "Failed to create TCP client".to_string(),
+                        )
+                    })?;
                     self.template_distribution_tcp_client
                         .write()
                         .await
@@ -411,13 +424,13 @@ where
 
         // Send the setup connection message using the io field
         tcp_client
-            .io
+            .io()
             .send_message(setup_connection.into(), MESSAGE_TYPE_SETUP_CONNECTION)
             .await?;
 
         // wait for the server to respond with a SetupConnectionSuccess or SetupConnectionError
         // and return the appropriate response
-        let (message, _) = tcp_client.io.recv_message().await?;
+        let (message, _) = tcp_client.io().recv_message().await?;
         match message {
             AnyMessage::Common(CommonMessages::SetupConnectionSuccess(
                 setup_connection_success,
@@ -452,7 +465,7 @@ where
             return Err(RequestToSv2ClientError::IsNotConnected);
         }
 
-        let tcp_client: Sv2EncryptedTcpClient = match protocol {
+        let tcp_client: Sv2TcpClient = match protocol {
             Protocol::MiningProtocol => match self.mining_tcp_client.read().await.as_ref() {
                 Some(client) => client.clone(),
                 None => return Err(RequestToSv2ClientError::IsNotConnected),
@@ -479,7 +492,7 @@ where
                     debug!("Message listener received shutdown signal");
                     break;
                 }
-                message_result = tcp_client.io.recv_message() => {
+                message_result = tcp_client.io().recv_message() => {
                     match message_result {
                         Ok((message, _)) => {
                             if let Err(e) = self.call(RequestToSv2Client::Message(message)).await {
@@ -899,7 +912,7 @@ where
                         );
 
                         let result = tcp_client
-                            .io
+                            .io()
                             .send_message(
                                 open_standard_mining_channel,
                                 MESSAGE_TYPE_OPEN_STANDARD_MINING_CHANNEL,
@@ -968,7 +981,7 @@ where
                         );
 
                         let result = tcp_client
-                            .io
+                            .io()
                             .send_message(
                                 open_extended_mining_channel,
                                 MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
@@ -1023,7 +1036,7 @@ where
                             ),
                         );
                         let result = tcp_client
-                            .io
+                            .io()
                             .send_message(
                                 coinbase_output_constraints,
                                 MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS,
@@ -1292,6 +1305,7 @@ mod tests {
             mining_config: None,
             job_declaration_config: None,
             template_distribution_config: Some(template_distribution_config.clone()),
+            encrypted: true,
         };
 
         let template_distribution_handler = DummyTemplateDistributionHandler;
@@ -1358,6 +1372,7 @@ mod tests {
             }),
             job_declaration_config: None,
             template_distribution_config: None,
+            encrypted: true,
         };
 
         let mining_handler = DummyMiningHandler;
@@ -1417,6 +1432,7 @@ mod tests {
             mining_config: None,
             job_declaration_config: None,
             template_distribution_config: None,
+            encrypted: true,
         };
 
         // add a dummy template distribution handler to (which is not null)
@@ -1455,6 +1471,7 @@ mod tests {
             mining_config: None,
             job_declaration_config: None,
             template_distribution_config: Some(template_distribution_config), // we are signaling that we support template distribution
+            encrypted: true,
         };
 
         // but now we are using a null template distribution handler, which is also not allowed
@@ -1491,6 +1508,7 @@ mod tests {
             mining_config: None,
             job_declaration_config: None,
             template_distribution_config: Some(template_distribution_config),
+            encrypted: true,
         };
 
         let template_distribution_handler = DummyTemplateDistributionHandler;
@@ -1545,6 +1563,7 @@ mod tests {
             mining_config: None,
             job_declaration_config: None,
             template_distribution_config: Some(template_distribution_config.clone()),
+            encrypted: true,
         };
 
         let template_distribution_handler = DummyTemplateDistributionHandler;

--- a/src/client/tcp/mod.rs
+++ b/src/client/tcp/mod.rs
@@ -1,14 +1,55 @@
-#[allow(unused_imports)]
+mod encrypted;
+
+mod unencrypted;
+
+use std::net::SocketAddr;
+
 use encrypted::Sv2EncryptedTcpClient;
-// #[allow(unused_imports)]
-// use unencrypted::Sv2UnencryptedTcpClient;
+use key_utils::Secp256k1PublicKey;
+use unencrypted::Sv2UnencryptedTcpClient;
 
-/// Provides a TCP client that connects to a server **with** Sv2 noise encryption
-///
-/// The main object of this module is [`Sv2EncryptedTcpClient`]
-pub mod encrypted;
+use crate::Sv2MessageIo;
 
-/// Provides a TCP client that connects to a server **without** Sv2 noise encryption
-///
-/// The main object of this module is [`Sv2UnencryptedTcpClient`]
-pub mod unencrypted;
+#[derive(Debug, Clone)]
+pub enum Sv2TcpClient {
+    /// Provides a TCP client that connects to a server **without** Sv2 noise encryption
+    ///
+    /// The main object of this module is [`Sv2UnencryptedTcpClient`]
+    Encrypted(Sv2EncryptedTcpClient),
+    /// Provides a TCP client that connects to a server **with** Sv2 noise encryption
+    ///
+    /// The main object of this module is [`Sv2EncryptedTcpClient`]
+    Unencrypted(Sv2UnencryptedTcpClient),
+}
+
+impl Sv2TcpClient {
+    pub fn shutdown(&self) {
+        match self {
+            Sv2TcpClient::Encrypted(client) => client.shutdown(),
+            Sv2TcpClient::Unencrypted(client) => client.shutdown(),
+        }
+    }
+
+    pub async fn new(
+        server_addr: SocketAddr,
+        encrypted: bool,
+        auth_pk: Option<Secp256k1PublicKey>,
+    ) -> Option<Self> {
+        if encrypted {
+            Sv2EncryptedTcpClient::new(server_addr, auth_pk)
+                .await
+                .map(Sv2TcpClient::Encrypted)
+        } else {
+            Sv2UnencryptedTcpClient::new(server_addr)
+                .await
+                .map(Sv2TcpClient::Unencrypted)
+        }
+    }
+
+    pub fn io(&self) -> &Sv2MessageIo {
+        match self {
+            Sv2TcpClient::Encrypted(client) => &client.io,
+            Sv2TcpClient::Unencrypted(client) => &client.io,
+        }
+    }
+}

--- a/src/client/tcp/unencrypted.rs
+++ b/src/client/tcp/unencrypted.rs
@@ -9,7 +9,7 @@ use crate::Sv2MessageIo;
 ///
 /// Note: [`Sv2UnencryptedTcpClient`] is NOT a [`tower::Service`],
 /// but rather a helper primitive to facilitate establishing unencrypted TCP connections
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Sv2UnencryptedTcpClient {
     /// IO of Sv2 Message Frames
     pub io: Sv2MessageIo,
@@ -28,6 +28,10 @@ impl Sv2UnencryptedTcpClient {
         let sv2_message_io = Sv2MessageIo { rx, tx };
         tracing::info!("connected to: {}", server_addr);
         Some(Self { io: sv2_message_io })
+    }
+
+    pub fn shutdown(&self) {
+        self.io.shutdown();
     }
 }
 

--- a/src/server/service/config.rs
+++ b/src/server/service/config.rs
@@ -50,6 +50,8 @@ pub struct Sv2ServerTcpConfig {
     pub priv_key: Secp256k1SecretKey,
     /// The validity of the server's certificate.
     pub cert_validity: u64,
+    /// TCP connection will be encrypted if this is set to true.
+    pub encrypted: bool,
 }
 
 /// Config parameters for the Mining subprotocol of a [`crate::server::service::Sv2ServerService`]

--- a/src/server/tcp/encrypted.rs
+++ b/src/server/tcp/encrypted.rs
@@ -72,7 +72,7 @@ pub async fn start_encrypted_tcp_server(
 
 #[cfg(test)]
 mod tests {
-    use crate::client::tcp::encrypted::Sv2EncryptedTcpClient;
+    use crate::client::tcp::Sv2TcpClient;
     use crate::Sv2MessageFrame;
     use const_sv2::{MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS};
     use framing_sv2::framing::Sv2Frame;
@@ -139,7 +139,7 @@ mod tests {
         .expect("Server should start successfully");
 
         // Connect client
-        let sv2_encrypted_tcp_client = Sv2EncryptedTcpClient::new(server_addr, Some(pub_key))
+        let sv2_encrypted_tcp_client = Sv2TcpClient::new(server_addr, true, Some(pub_key))
             .await
             .unwrap();
 
@@ -165,7 +165,7 @@ mod tests {
 
         // Send SetupConnection from client
         sv2_encrypted_tcp_client
-            .io
+            .io()
             .send_message(setup_connection.into(), MESSAGE_TYPE_SETUP_CONNECTION)
             .await
             .unwrap();
@@ -207,7 +207,7 @@ mod tests {
             .unwrap();
 
         // Receive frame on client side
-        let received_frame = sv2_encrypted_tcp_client.io.rx.recv().await.unwrap();
+        let received_frame = sv2_encrypted_tcp_client.io().rx.recv().await.unwrap();
 
         // Assert received frame
         if let Sv2MessageFrame::Sv2(frame) = received_frame {

--- a/src/server/tcp/unencrypted.rs
+++ b/src/server/tcp/unencrypted.rs
@@ -50,7 +50,7 @@ pub async fn start_unencrypted_tcp_server(
 
 #[cfg(test)]
 mod tests {
-    use crate::client::tcp::unencrypted::Sv2UnencryptedTcpClient;
+    use crate::client::tcp::Sv2TcpClient;
     use crate::Sv2MessageFrame;
     use const_sv2::{MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS};
     use framing_sv2::framing::Sv2Frame;
@@ -97,7 +97,7 @@ mod tests {
             .expect("Server should start successfully");
 
         // connect client
-        let sv2_unencrypted_tcp_client = Sv2UnencryptedTcpClient::new(server_addr).await.unwrap();
+        let sv2_unencrypted_tcp_client = Sv2TcpClient::new(server_addr, false, None).await.unwrap();
 
         // SetupConnection message
         let setup_connection = SetupConnection {
@@ -126,7 +126,7 @@ mod tests {
 
         // send SetupConnection from client
         sv2_unencrypted_tcp_client
-            .io
+            .io()
             .tx
             .send(setup_connection_frame)
             .await
@@ -175,7 +175,7 @@ mod tests {
             .unwrap();
 
         // receive frame on client side
-        let received_frame = sv2_unencrypted_tcp_client.io.rx.recv().await.unwrap();
+        let received_frame = sv2_unencrypted_tcp_client.io().rx.recv().await.unwrap();
 
         // assert received frame
         if let Sv2MessageFrame::Sv2(frame) = received_frame {


### PR DESCRIPTION
closes #2;

introduced support for both encrypted and unencrypted TCP connections in the client and server components of the system. It refactors the TCP client implementation to handle both connection types dynamically and updates the server to start the appropriate TCP server based on configuration. 
Additionally, the changes include updates to configuration structures and test cases to support the new functionality.