### PR TITLE
bootstrap `mining-client-cpu-miner` example

### DIFF
--- a/examples/mining-client-cpu-miner/Cargo.toml
+++ b/examples/mining-client-cpu-miner/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mining-client-cpu-miner"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tower-stratum = { path = "../.." }
+tokio = { version = "1", features = ["full", "tracing", "signal"] }
+tracing = "0.1"
+hex = "0.4.3"
+tracing-subscriber = "0.3.19"
+binary_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
+framing_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
+const_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
+roles_logic_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
+key-utils = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
+anyhow = "1.0"
+clap = { version = "4.4", features = ["derive"] }
+toml = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+integration_tests_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }

--- a/examples/mining-client-cpu-miner/README.md
+++ b/examples/mining-client-cpu-miner/README.md
@@ -1,0 +1,31 @@
+# Mining Client CPU Miner Example
+
+This example demonstrates some basic patterns for using `tower-stratum` to build a Sv2 Client Service, with focus on the Mining Protocol.
+
+More specifically, we implement a CPU miner.
+
+The user chooses between two possible operation modes:
+- Standard Channel (no extranonce rolling aka Header Only mining)
+- Extended Channel (extranonce rolling)
+
+## `config` module
+
+The `config` module is reponsible for pasing a `.toml` file, which should contain the basic information needed for the Client Service:
+
+- `server_addr`: IP and port of the Sv2 Mining Server
+- `auth_pk`: authority Public Key of the Sv2 Mining Server
+- `extranonce_rolling`: chooses between Standard vs Extended Channel mode
+
+# `client` module
+
+The `client` module illustrates how to utilize the `Sv2ClientService` while building some applciation. Three methods are implemented:
+- `new`: loads a `Sv2ClientServiceConfig`, where the most relevant info are:
+  - `supported_protocols`: a reference to the Mining Protocol
+  - `mining_config`: a reference to a `Sv2ClientServiceMiningConfig` setting the `extranonce_rolling` flag
+  - `start`: calls `Sv2ClientService`'s `start` method
+  - `shutdown`: calls `Sv2ClientService`'s `shutdown` method
+
+
+## `handler` module
+
+The `handler` module illustrates how to implement the `Sv2MiningClientHandler` trait, with functions that are responsible for handling different messages that a Client could potentially receive under the Sv2 Mining Protocol.

--- a/examples/mining-client-cpu-miner/config.toml
+++ b/examples/mining-client-cpu-miner/config.toml
@@ -1,0 +1,4 @@
+server_addr = "127.0.0.1:3333"
+auth_pk = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+extranonce_rolling = true
+user_identity = "tower-stratum-mining-client-example"

--- a/examples/mining-client-cpu-miner/src/client.rs
+++ b/examples/mining-client-cpu-miner/src/client.rs
@@ -1,0 +1,133 @@
+use crate::config::MyMiningClientConfig;
+use crate::handler::MyMiningClientHandler;
+use anyhow::{Result, anyhow};
+use tower_stratum::client::service::Sv2ClientService;
+use tower_stratum::client::service::config::Sv2ClientServiceConfig;
+use tower_stratum::client::service::config::Sv2ClientServiceMiningConfig;
+use tower_stratum::client::service::request::RequestToSv2Client;
+use tower_stratum::client::service::response::ResponseFromSv2Client;
+use tower_stratum::client::service::subprotocols::mining::request::RequestToSv2MiningClientService;
+use tower_stratum::client::service::subprotocols::mining::response::ResponseToMiningTrigger;
+use tower_stratum::client::service::subprotocols::template_distribution::handler::NullSv2TemplateDistributionClientHandler;
+use tower_stratum::tower::{Service, ServiceExt};
+use tracing::info;
+pub struct MyMiningClient {
+    sv2_client_service:
+        Sv2ClientService<MyMiningClientHandler, NullSv2TemplateDistributionClientHandler>,
+    user_identity: String,
+    extranonce_rolling: bool,
+}
+
+impl MyMiningClient {
+    pub async fn new(config: MyMiningClientConfig) -> Result<Self> {
+        let service_config = Sv2ClientServiceConfig {
+            min_supported_version: 2,
+            max_supported_version: 2,
+            endpoint_host: None,
+            endpoint_port: None,
+            vendor: None,
+            hardware_version: None,
+            firmware: None,
+            device_id: None,
+            mining_config: Some(Sv2ClientServiceMiningConfig {
+                server_addr: config.server_addr,
+                auth_pk: config.auth_pk,
+                // REQUIRES_VERSION_ROLLING, !REQUIRES_WORK_SELECTION, REQUIRES_STANDARD_JOBS
+                setup_connection_flags: 0b001 as u32,
+            }),
+            job_declaration_config: None,
+            template_distribution_config: None,
+        };
+
+        let template_distribution_handler = NullSv2TemplateDistributionClientHandler;
+
+        let mining_handler = MyMiningClientHandler::default();
+
+        let sv2_client_service = Sv2ClientService::new(
+            service_config,
+            mining_handler,
+            template_distribution_handler,
+        )
+        .map_err(|e| anyhow!("Failed to create Sv2ClientService: {:?}", e))?;
+
+        Ok(Self {
+            sv2_client_service,
+            user_identity: config.user_identity,
+            extranonce_rolling: config.extranonce_rolling,
+        })
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        self.sv2_client_service
+            .start()
+            .await
+            .map_err(|e| anyhow!("Failed to start Sv2ClientService: {:?}", e))?;
+        self.sv2_client_service
+            .ready()
+            .await
+            .map_err(|e| anyhow!("Service is not ready: {:?}", e))?;
+
+        // todo: try to open extended or standard channel with the server
+        // depending on the extranonce_rolling config parameter
+        match self.extranonce_rolling {
+            false => {
+                let open_standard_mining_channel_response = self
+                    .sv2_client_service
+                    .call(RequestToSv2Client::MiningTrigger(
+                        RequestToSv2MiningClientService::OpenStandardMiningChannel(
+                            0, // todo
+                            self.user_identity.clone(),
+                            10.0,                                  // todo
+                            vec![0xFF_u8; 32].try_into().unwrap(), // todo
+                        ),
+                    ))
+                    .await
+                    .map_err(|e| anyhow!("Failed to open standard mining channel: {:?}", e))?;
+
+                match open_standard_mining_channel_response {
+                    ResponseFromSv2Client::ResponseToMiningTrigger(
+                        ResponseToMiningTrigger::SuccessfullySentOpenStandardMiningChannelMessage,
+                    ) => {
+                        info!("Successfully sent open standard mining channel request");
+                    }
+                    _ => {
+                        return Err(anyhow!("Failed to open standard mining channel"));
+                    }
+                }
+            }
+            true => {
+                let open_extended_mining_channel_response = self
+                    .sv2_client_service
+                    .call(RequestToSv2Client::MiningTrigger(
+                        RequestToSv2MiningClientService::OpenExtendedMiningChannel(
+                            0, // todo
+                            self.user_identity.clone(),
+                            10.0,                                  // todo
+                            vec![0xFF_u8; 32].try_into().unwrap(), // todo
+                            1,
+                        ),
+                    ))
+                    .await
+                    .map_err(|e| anyhow!("Failed to open extended mining channel: {:?}", e))?;
+
+                match open_extended_mining_channel_response {
+                    ResponseFromSv2Client::ResponseToMiningTrigger(
+                        ResponseToMiningTrigger::SuccessfullySentOpenExtendedMiningChannelMessage,
+                    ) => {
+                        info!("Successfully sent open extended mining channel request");
+                    }
+                    _ => {
+                        return Err(anyhow!("Failed to open extended mining channel"));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn shutdown(&mut self) {
+        info!("Shutting down Mining Client");
+        self.sv2_client_service.shutdown().await;
+    }
+}

--- a/examples/mining-client-cpu-miner/src/config.rs
+++ b/examples/mining-client-cpu-miner/src/config.rs
@@ -1,0 +1,21 @@
+use key_utils::Secp256k1PublicKey;
+use serde::Deserialize;
+use std::fs;
+use std::net::SocketAddr;
+use std::path::Path;
+
+#[derive(Deserialize)]
+pub struct MyMiningClientConfig {
+    pub server_addr: SocketAddr,
+    pub auth_pk: Option<Secp256k1PublicKey>,
+    pub extranonce_rolling: bool,
+    pub user_identity: String,
+}
+
+impl MyMiningClientConfig {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+        let contents = fs::read_to_string(path)?;
+        let config: Self = toml::from_str(&contents)?;
+        Ok(config)
+    }
+}

--- a/examples/mining-client-cpu-miner/src/handler.rs
+++ b/examples/mining-client-cpu-miner/src/handler.rs
@@ -1,0 +1,154 @@
+use roles_logic_sv2::mining_sv2::{
+    CloseChannel, NewExtendedMiningJob, NewMiningJob, OpenExtendedMiningChannelSuccess,
+    OpenMiningChannelError, OpenStandardMiningChannelSuccess, SetCustomMiningJobError,
+    SetCustomMiningJobSuccess, SetExtranoncePrefix, SetGroupChannel, SetNewPrevHash, SetTarget,
+    SubmitSharesError, SubmitSharesSuccess, UpdateChannelError,
+};
+use std::task::{Context, Poll};
+use tower_stratum::client::service::request::RequestToSv2ClientError;
+use tower_stratum::client::service::response::ResponseFromSv2Client;
+use tower_stratum::client::service::subprotocols::mining::handler::Sv2MiningClientHandler;
+
+use tracing::info;
+
+#[derive(Debug, Clone, Default)]
+pub struct MyMiningClientHandler {
+    // You could add fields here to store state or callbacks
+}
+
+impl Sv2MiningClientHandler for MyMiningClientHandler {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), RequestToSv2ClientError>> {
+        Poll::Ready(Ok(()))
+    }
+
+    async fn handle_open_standard_mining_channel_success(
+        &self,
+        open_standard_mining_channel_success: OpenStandardMiningChannelSuccess<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!(
+            "received OpenStandardMiningChannel.Success: {:?}",
+            open_standard_mining_channel_success
+        );
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_open_extended_mining_channel_success(
+        &self,
+        open_extended_mining_channel_success: OpenExtendedMiningChannelSuccess<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!(
+            "received OpenExtendedMiningChannel.Success: {:?}",
+            open_extended_mining_channel_success
+        );
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_open_mining_channel_error(
+        &self,
+        open_standard_mining_channel_error: OpenMiningChannelError<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!(
+            "received OpenMiningChannel.Error: {:?}",
+            open_standard_mining_channel_error
+        );
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_update_channel_error(
+        &self,
+        update_channel_error: UpdateChannelError<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received UpdateChannel.Error: {:?}", update_channel_error);
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_close_channel(
+        &self,
+        close_channel: CloseChannel<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received CloseChannel: {:?}", close_channel);
+        todo!()
+    }
+
+    async fn handle_set_extranonce_prefix(
+        &self,
+        set_extranonce_prefix: SetExtranoncePrefix<'static>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received SetExtranoncePrefix: {:?}", set_extranonce_prefix);
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_submit_shares_success(
+        &self,
+        submit_shares_success: SubmitSharesSuccess,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received SubmitShares.Success: {:?}", submit_shares_success);
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_submit_shares_error(
+        &self,
+        submit_shares_error: SubmitSharesError<'_>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received SubmitShares.Error: {:?}", submit_shares_error);
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_new_mining_job(
+        &self,
+        new_mining_job: NewMiningJob<'_>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received NewMiningJob: {:?}", new_mining_job);
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_new_extended_mining_job(
+        &self,
+        _new_extended_mining_job: NewExtendedMiningJob<'_>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!(
+            "received NewExtendedMiningJob: {:?}",
+            _new_extended_mining_job
+        );
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_set_new_prev_hash(
+        &self,
+        _set_new_prev_hash: SetNewPrevHash<'_>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received SetNewPrevHash: {:?}", _set_new_prev_hash);
+        // todo!()
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_set_custom_mining_job_success(
+        &self,
+        _set_custom_mining_job_success: SetCustomMiningJobSuccess,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        unimplemented!("CPU Miner never sends SetCustomMiningJob");
+    }
+
+    async fn handle_set_custom_mining_job_error(
+        &self,
+        _set_custom_mining_job_error: SetCustomMiningJobError<'_>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        unimplemented!("CPU Miner never sends SetCustomMiningJob");
+    }
+
+    async fn handle_set_target(
+        &self,
+        _set_target: SetTarget<'_>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received SetTarget: {:?}", _set_target);
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+
+    async fn handle_set_group_channel(
+        &self,
+        _set_group_channel: SetGroupChannel<'_>,
+    ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
+        info!("received SetGroupChannel: {:?}", _set_group_channel);
+        Ok(ResponseFromSv2Client::ToDo)
+    }
+}

--- a/examples/mining-client-cpu-miner/src/main.rs
+++ b/examples/mining-client-cpu-miner/src/main.rs
@@ -1,0 +1,104 @@
+mod client;
+mod config;
+mod handler;
+
+use crate::client::MyMiningClient;
+use crate::config::MyMiningClientConfig;
+
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to the TOML configuration file
+    #[arg(short, long)]
+    config: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize logging
+    tracing_subscriber::fmt().init();
+
+    // Parse command line arguments
+    let args = Args::parse();
+
+    // Load configuration from file
+    let config = MyMiningClientConfig::from_file(args.config)?;
+
+    // Create and start the client
+    let mut client = MyMiningClient::new(config).await?;
+
+    // Start the client service
+    client.start().await?;
+
+    // Wait for Ctrl+C
+    tokio::signal::ctrl_c().await?;
+
+    // Shutdown the client
+    client.shutdown().await;
+
+    Ok(())
+}
+
+mod tests {
+    use crate::client::MyMiningClient;
+    use crate::config::MyMiningClientConfig;
+    use const_sv2::*;
+    use integration_tests_sv2::{
+        sniffer::MessageDirection, start_pool, start_sniffer, start_template_provider,
+    };
+    #[tokio::test]
+    async fn test_mining_client_standard_channel() {
+        tracing_subscriber::fmt().init();
+
+        let (_tp, tp_addr) = start_template_provider(None);
+        let (_pool, pool_addr) = start_pool(Some(tp_addr)).await;
+        let (sniffer, sniffer_addr) = start_sniffer("".to_string(), pool_addr, false, None).await;
+
+        // Give sniffer time to initialize
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let config = MyMiningClientConfig {
+            server_addr: sniffer_addr,
+            auth_pk: None,
+            extranonce_rolling: false, // standard jobs
+            user_identity: "test".to_string(),
+        };
+
+        let mut client = MyMiningClient::new(config).await.unwrap();
+        client.start().await.unwrap();
+
+        sniffer
+            .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+            .await;
+        sniffer
+            .wait_for_message_type(
+                MessageDirection::ToDownstream,
+                MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+            )
+            .await;
+        sniffer
+            .wait_for_message_type(
+                MessageDirection::ToUpstream,
+                MESSAGE_TYPE_OPEN_STANDARD_MINING_CHANNEL,
+            )
+            .await;
+        sniffer
+            .wait_for_message_type(
+                MessageDirection::ToDownstream,
+                MESSAGE_TYPE_OPEN_STANDARD_MINING_CHANNEL_SUCCESS,
+            )
+            .await;
+        sniffer
+            .wait_for_message_type(MessageDirection::ToDownstream, MESSAGE_TYPE_NEW_MINING_JOB)
+            .await;
+        sniffer
+            .wait_for_message_type(
+                MessageDirection::ToDownstream,
+                MESSAGE_TYPE_MINING_SET_NEW_PREV_HASH,
+            )
+            .await;
+    }
+}


### PR DESCRIPTION
this example builds on top of e1e4680a1ffc50427e3e641179004d82fa3d6373 + de6d909bae4c85e19b75b20081b921efb6830d81

still todo: implement handlers, add channel management and actually do some CPU mining