### PR TITLE
simplify response variants

### DIFF
--- a/examples/mining-client-cpu-miner/src/client.rs
+++ b/examples/mining-client-cpu-miner/src/client.rs
@@ -7,7 +7,6 @@ use tower_stratum::client::service::config::Sv2ClientServiceMiningConfig;
 use tower_stratum::client::service::request::RequestToSv2Client;
 use tower_stratum::client::service::response::ResponseFromSv2Client;
 use tower_stratum::client::service::subprotocols::mining::request::RequestToSv2MiningClientService;
-use tower_stratum::client::service::subprotocols::mining::response::ResponseToMiningTrigger;
 use tower_stratum::client::service::subprotocols::template_distribution::handler::NullSv2TemplateDistributionClientHandler;
 use tower_stratum::tower::{Service, ServiceExt};
 use tracing::info;
@@ -85,9 +84,7 @@ impl MyMiningClient {
                     .map_err(|e| anyhow!("Failed to open standard mining channel: {:?}", e))?;
 
                 match open_standard_mining_channel_response {
-                    ResponseFromSv2Client::ResponseToMiningTrigger(
-                        ResponseToMiningTrigger::SuccessfullySentOpenStandardMiningChannelMessage,
-                    ) => {
+                    ResponseFromSv2Client::Ok => {
                         info!("Successfully sent open standard mining channel request");
                     }
                     _ => {
@@ -111,9 +108,7 @@ impl MyMiningClient {
                     .map_err(|e| anyhow!("Failed to open extended mining channel: {:?}", e))?;
 
                 match open_extended_mining_channel_response {
-                    ResponseFromSv2Client::ResponseToMiningTrigger(
-                        ResponseToMiningTrigger::SuccessfullySentOpenExtendedMiningChannelMessage,
-                    ) => {
+                    ResponseFromSv2Client::Ok => {
                         info!("Successfully sent open extended mining channel request");
                     }
                     _ => {

--- a/examples/mining-client-cpu-miner/src/handler.rs
+++ b/examples/mining-client-cpu-miner/src/handler.rs
@@ -29,7 +29,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
             "received OpenStandardMiningChannel.Success: {:?}",
             open_standard_mining_channel_success
         );
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_open_extended_mining_channel_success(
@@ -40,7 +40,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
             "received OpenExtendedMiningChannel.Success: {:?}",
             open_extended_mining_channel_success
         );
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_open_mining_channel_error(
@@ -51,7 +51,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
             "received OpenMiningChannel.Error: {:?}",
             open_standard_mining_channel_error
         );
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_update_channel_error(
@@ -59,7 +59,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
         update_channel_error: UpdateChannelError<'static>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
         info!("received UpdateChannel.Error: {:?}", update_channel_error);
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_close_channel(
@@ -75,7 +75,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
         set_extranonce_prefix: SetExtranoncePrefix<'static>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
         info!("received SetExtranoncePrefix: {:?}", set_extranonce_prefix);
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_submit_shares_success(
@@ -83,7 +83,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
         submit_shares_success: SubmitSharesSuccess,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
         info!("received SubmitShares.Success: {:?}", submit_shares_success);
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_submit_shares_error(
@@ -91,7 +91,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
         submit_shares_error: SubmitSharesError<'_>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
         info!("received SubmitShares.Error: {:?}", submit_shares_error);
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_new_mining_job(
@@ -99,7 +99,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
         new_mining_job: NewMiningJob<'_>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
         info!("received NewMiningJob: {:?}", new_mining_job);
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_new_extended_mining_job(
@@ -110,7 +110,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
             "received NewExtendedMiningJob: {:?}",
             _new_extended_mining_job
         );
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_set_new_prev_hash(
@@ -119,7 +119,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
         info!("received SetNewPrevHash: {:?}", _set_new_prev_hash);
         // todo!()
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_set_custom_mining_job_success(
@@ -141,7 +141,7 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
         _set_target: SetTarget<'_>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
         info!("received SetTarget: {:?}", _set_target);
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 
     async fn handle_set_group_channel(
@@ -149,6 +149,6 @@ impl Sv2MiningClientHandler for MyMiningClientHandler {
         _set_group_channel: SetGroupChannel<'_>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
         info!("received SetGroupChannel: {:?}", _set_group_channel);
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(ResponseFromSv2Client::Ok)
     }
 }

--- a/examples/sibling-io-communication/src/mining_server_handler.rs
+++ b/examples/sibling-io-communication/src/mining_server_handler.rs
@@ -32,7 +32,7 @@ impl Sv2MiningServerHandler for MyMiningServerHandler {
 
         // Store the latest template ID for assertions in tests
 
-        Ok(ResponseFromSv2Server::ToDo)
+        Ok(ResponseFromSv2Server::Ok)
     }
 
     async fn on_set_new_prev_hash(
@@ -40,7 +40,7 @@ impl Sv2MiningServerHandler for MyMiningServerHandler {
         m: SetNewPrevHash<'static>,
     ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
         info!(prev_hash = ?m.prev_hash, "MiningServer: Received new previous hash");
-        Ok(ResponseFromSv2Server::ToDo)
+        Ok(ResponseFromSv2Server::Ok)
     }
 
     fn setup_connection_success_flags(&self) -> u32 {

--- a/examples/sibling-io-communication/src/mining_server_handler.rs
+++ b/examples/sibling-io-communication/src/mining_server_handler.rs
@@ -30,8 +30,6 @@ impl Sv2MiningServerHandler for MyMiningServerHandler {
             "MiningServer: Received new template"
         );
 
-        // Store the latest template ID for assertions in tests
-
         Ok(ResponseFromSv2Server::Ok)
     }
 

--- a/examples/template-distribution-client/src/client.rs
+++ b/examples/template-distribution-client/src/client.rs
@@ -9,7 +9,6 @@ use tower_stratum::client::service::request::RequestToSv2Client;
 use tower_stratum::client::service::response::ResponseFromSv2Client;
 use tower_stratum::client::service::subprotocols::mining::handler::NullSv2MiningClientHandler;
 use tower_stratum::client::service::subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService;
-use tower_stratum::client::service::subprotocols::template_distribution::response::ResponseToTemplateDistributionTrigger;
 use tracing::info;
 
 pub struct MyTemplateDistributionClient {
@@ -83,9 +82,7 @@ impl MyTemplateDistributionClient {
             .map_err(|e| anyhow!("Failed to request coinbase output constraints: {:?}", e))?;
 
         match set_coinbase_output_constraints_response {
-            ResponseFromSv2Client::ResponseToTemplateDistributionTrigger(
-                ResponseToTemplateDistributionTrigger::SuccessfullySetCoinbaseOutputConstraints,
-            ) => {
+            ResponseFromSv2Client::Ok => {
                 info!("Coinbase output constraints set");
             }
             _ => {

--- a/src/client/service/mod.rs
+++ b/src/client/service/mod.rs
@@ -6,11 +6,9 @@ use crate::client::service::sibling::Sv2SiblingServerServiceIo;
 use crate::client::service::subprotocols::mining::handler::NullSv2MiningClientHandler;
 use crate::client::service::subprotocols::mining::handler::Sv2MiningClientHandler;
 use crate::client::service::subprotocols::mining::request::RequestToSv2MiningClientService;
-use crate::client::service::subprotocols::mining::response::ResponseToMiningTrigger;
 use crate::client::service::subprotocols::template_distribution::handler::NullSv2TemplateDistributionClientHandler;
 use crate::client::service::subprotocols::template_distribution::handler::Sv2TemplateDistributionClientHandler;
 use crate::client::service::subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService;
-use crate::client::service::subprotocols::template_distribution::response::ResponseToTemplateDistributionTrigger;
 use crate::client::tcp::encrypted::Sv2EncryptedTcpClient;
 use const_sv2::MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS;
 use const_sv2::MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL;
@@ -908,7 +906,7 @@ where
                         match result {
                             Ok(_) => {
                                 debug!("Successfully sent OpenStandardMiningChannel");
-                                Ok(ResponseFromSv2Client::ResponseToMiningTrigger(ResponseToMiningTrigger::SuccessfullySentOpenStandardMiningChannelMessage))
+                                Ok(ResponseFromSv2Client::Ok)
                             }
                             Err(e) => Err(e.into()),
                         }
@@ -977,7 +975,7 @@ where
                         match result {
                             Ok(_) => {
                                 debug!("Successfully sent OpenExtendedMiningChannel");
-                                Ok(ResponseFromSv2Client::ResponseToMiningTrigger(ResponseToMiningTrigger::SuccessfullySentOpenExtendedMiningChannelMessage))
+                                Ok(ResponseFromSv2Client::Ok)
                             }
                             Err(e) => Err(e.into()),
                         }
@@ -1038,7 +1036,7 @@ where
                                     .expect("template_distribution_config should be Some")
                                     .coinbase_output_constraints =
                                     (max_additional_size, max_additional_sigops);
-                                Ok(ResponseFromSv2Client::ResponseToTemplateDistributionTrigger(ResponseToTemplateDistributionTrigger::SuccessfullySetCoinbaseOutputConstraints))
+                                Ok(ResponseFromSv2Client::Ok)
                             }
                             Err(e) => Err(e.into()),
                         }
@@ -1057,9 +1055,7 @@ where
                             io.send(*req.clone()).map_err(|_| {
                                 RequestToSv2ClientError::FailedToSendRequestToSiblingServerService
                             })?;
-                            Ok(ResponseFromSv2Client::SentRequestToSiblingServerService(
-                                *req,
-                            ))
+                            Ok(ResponseFromSv2Client::Ok)
                         }
                         None => {
                             error!("No sibling server service on Sv2ClientService");
@@ -1364,14 +1360,14 @@ mod tests {
             &self,
             _m: NewTemplate<'static>,
         ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
-            Ok(ResponseFromSv2Server::ToDo)
+            Ok(ResponseFromSv2Server::Ok)
         }
 
         async fn on_set_new_prev_hash(
             &self,
             _m: SetNewPrevHash<'static>,
         ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
-            Ok(ResponseFromSv2Server::ToDo)
+            Ok(ResponseFromSv2Server::Ok)
         }
 
         fn setup_connection_success_flags(&self) -> u32 {
@@ -1389,7 +1385,7 @@ mod tests {
             _client_id: u32,
             _m: OpenStandardMiningChannel<'static>,
         ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
-            Ok(ResponseFromSv2Server::ToDo)
+            Ok(ResponseFromSv2Server::Ok)
         }
 
         async fn handle_open_extended_mining_channel(
@@ -1397,7 +1393,7 @@ mod tests {
             _client_id: u32,
             _m: OpenExtendedMiningChannel<'static>,
         ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
-            Ok(ResponseFromSv2Server::ToDo)
+            Ok(ResponseFromSv2Server::Ok)
         }
 
         async fn handle_update_channel(
@@ -1405,7 +1401,7 @@ mod tests {
             _client_id: u32,
             _m: UpdateChannel<'static>,
         ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
-            Ok(ResponseFromSv2Server::ToDo)
+            Ok(ResponseFromSv2Server::Ok)
         }
 
         async fn handle_close_channel(
@@ -1413,7 +1409,7 @@ mod tests {
             _client_id: u32,
             _m: CloseChannel<'static>,
         ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
-            Ok(ResponseFromSv2Server::ToDo)
+            Ok(ResponseFromSv2Server::Ok)
         }
 
         async fn handle_submit_shares_standard(
@@ -1421,7 +1417,7 @@ mod tests {
             _client_id: u32,
             _m: SubmitSharesStandard,
         ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
-            Ok(ResponseFromSv2Server::ToDo)
+            Ok(ResponseFromSv2Server::Ok)
         }
 
         async fn handle_submit_shares_extended(
@@ -1429,7 +1425,7 @@ mod tests {
             _client_id: u32,
             _m: SubmitSharesExtended<'static>,
         ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
-            Ok(ResponseFromSv2Server::ToDo)
+            Ok(ResponseFromSv2Server::Ok)
         }
 
         async fn handle_set_custom_mining_job(
@@ -1437,7 +1433,7 @@ mod tests {
             _client_id: u32,
             _m: SetCustomMiningJob<'static>,
         ) -> Result<ResponseFromSv2Server<'static>, RequestToSv2ServerError> {
-            Ok(ResponseFromSv2Server::ToDo)
+            Ok(ResponseFromSv2Server::Ok)
         }
     }
 
@@ -1918,9 +1914,7 @@ mod tests {
         // Assert that the response was sent to the sibling server.
         assert!(matches!(
             new_template_response.as_ref().unwrap(),
-            ResponseFromSv2Client::SentRequestToSiblingServerService(
-                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::NewTemplate(_))
-            )
+            ResponseFromSv2Client::Ok
         ));
 
         // Create a dummy SetNewPrevHash message to simulate a new previous hash.
@@ -1943,12 +1937,7 @@ mod tests {
             .unwrap();
 
         // Assert that the response from the MiningServerHandler is received.
-        assert!(matches!(
-            new_prev_hash_response,
-            ResponseFromSv2Client::SentRequestToSiblingServerService(
-                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::SetNewPrevHash(_))
-            )
-        ));
+        assert!(matches!(new_prev_hash_response, ResponseFromSv2Client::Ok));
 
         // Shutdown the server and client services gracefully.
         server_service.shutdown().await;

--- a/src/client/service/response.rs
+++ b/src/client/service/response.rs
@@ -1,17 +1,10 @@
 use crate::client::service::request::RequestToSv2Client;
-use crate::client::service::subprotocols::mining::response::ResponseToMiningTrigger;
-use crate::client::service::subprotocols::template_distribution::response::ResponseToTemplateDistributionTrigger;
-use crate::server::service::request::RequestToSv2Server;
 use roles_logic_sv2::parsers::AnyMessage;
 
 /// The response type for the tower service [`crate::client::service::Sv2ClientService`].
 #[derive(Debug)]
 pub enum ResponseFromSv2Client<'a> {
     SendToServer(AnyMessage<'a>),
-    ResponseToTemplateDistributionTrigger(ResponseToTemplateDistributionTrigger),
-    ResponseToMiningTrigger(ResponseToMiningTrigger),
     TriggerNewRequest(RequestToSv2Client<'a>),
-    SentRequestToSiblingServerService(RequestToSv2Server<'a>),
     Ok,
-    ToDo, // dummy placeholder for future response types (e.g.: Relay)
 }

--- a/src/client/service/subprotocols/mining/mod.rs
+++ b/src/client/service/subprotocols/mining/mod.rs
@@ -1,3 +1,2 @@
 pub mod handler;
 pub mod request;
-pub mod response;

--- a/src/client/service/subprotocols/mining/response.rs
+++ b/src/client/service/subprotocols/mining/response.rs
@@ -1,5 +1,0 @@
-#[derive(Debug, Clone)]
-pub enum ResponseToMiningTrigger {
-    SuccessfullySentOpenStandardMiningChannelMessage,
-    SuccessfullySentOpenExtendedMiningChannelMessage,
-}

--- a/src/client/service/subprotocols/template_distribution/mod.rs
+++ b/src/client/service/subprotocols/template_distribution/mod.rs
@@ -1,3 +1,2 @@
 pub mod handler;
 pub mod request;
-pub mod response;

--- a/src/client/service/subprotocols/template_distribution/response.rs
+++ b/src/client/service/subprotocols/template_distribution/response.rs
@@ -1,5 +1,0 @@
-/// Responses that are specific to Triggers under the Template Distribution protocol
-#[derive(Debug)]
-pub enum ResponseToTemplateDistributionTrigger {
-    SuccessfullySetCoinbaseOutputConstraints,
-}

--- a/src/server/service/mod.rs
+++ b/src/server/service/mod.rs
@@ -824,9 +824,7 @@ where
                             io.send(*req.clone()).map_err(|_| {
                                 RequestToSv2ServerError::FailedToSendRequestToSiblingClientService
                             })?;
-                            Ok(ResponseFromSv2Server::SentRequestToSiblingClientService(
-                                *req,
-                            ))
+                            Ok(ResponseFromSv2Server::Ok)
                         }
                         None => {
                             error!("No sibling client service on Sv2ServerService");
@@ -861,9 +859,7 @@ where
 
                 match io.send_message(message, message_type).await {
                     Ok(_) => {
-                        return Ok(ResponseFromSv2Server::SentReplyToClient(
-                            sv2_message_to_client,
-                        ))
+                        return Ok(ResponseFromSv2Server::Ok);
                     }
                     Err(_) => return Err(RequestToSv2ServerError::FailedToSendResponseToClient),
                 }

--- a/src/server/service/response.rs
+++ b/src/server/service/response.rs
@@ -1,6 +1,5 @@
 use roles_logic_sv2::parsers::AnyMessage;
 
-use crate::client::service::request::RequestToSv2Client;
 use crate::server::service::request::RequestToSv2Server;
 /// A reply containing a Sv2 message, to be delivered back to the client.
 #[derive(Debug, Clone)]
@@ -15,9 +14,6 @@ pub struct Sv2MessageToClient<'a> {
 pub enum ResponseFromSv2Server<'a> {
     // triggers the service to send a reply to the client
     SendReplyToClient(Sv2MessageToClient<'a>),
-    // indicates that the service has sent a reply to the client
-    SentReplyToClient(Sv2MessageToClient<'a>),
-    SentRequestToSiblingClientService(RequestToSv2Client<'a>),
     TriggerNewRequest(RequestToSv2Server<'a>),
-    ToDo, // dummy placeholder for future response types (e.g.: Relay)
+    Ok,
 }


### PR DESCRIPTION
the `ToDo` response variant was a dirty hack I introduced in the early stages of prototyping, without a clear plan for it... now it started to leak into other parts of the code, like some of the dummy handlers we use on tests

so I thought it would be a good idea to replace them with a simple `Ok` variant

and as I did that replacement, I realized there was a bit of overengineering around other response variants, namely:
- `ResponseFromSv2Client::SentRequestToSiblingServerService(RequestToSv2Server<'a>)`
- `ResponseFromSv2Server::SentReplyToClient(Sv2MessageToClient<'a>)`,
- `ResponseFromSv2Server::SentRequestToSiblingClientService(RequestToSv2Client<'a>)`

while these acknowledgement response variants are arguably useful for assertions in the tests, they also make the code harder to understand

that gets even worse when we start nesting/concatenating them, like in:
- `ResponseFromSv2Client::ResponseToTemplateDistributionTrigger(ResponseToTemplateDistributionTrigger)` (with subvariants like `ResponseToTemplateDistributionTrigger::SuccessfullySetCoinbaseOutputConstraints`)
- `ResponseFromSv2Client::ResponseToMiningTrigger(ResponseToMiningTrigger)` (with subvariants like `ResponseToMiningTrigger::SuccessfullySentOpenStandardMiningChannelMessage` and `ResponseToMiningTrigger::SuccessfullySentOpenExtendedMiningChannelMessage`)

so I guess it should be enough to replace them with a simple `Ok`, and leave more elaborate variants for scenarios where we want to use the response type to trigger new behavior, such as:
- `ResponseFromSv2Server::SendReplyToClient(Sv2MessageToClient<'a>)`
- `ResponseFromSv2Server::TriggerNewRequest(RequestToSv2Server<'a>)`
- `ResponseFromSv2Client::SendToServer(AnyMessage<'a>)`
- `ResponseFromSv2Client::TriggerNewRequest(RequestToSv2Client<'a>)`