### PR TITLE
only send messages via `TriggerNewRequest`

### DIFF
--- a/src/client/service/mod.rs
+++ b/src/client/service/mod.rs
@@ -16,9 +16,6 @@ use roles_logic_sv2::mining_sv2::MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL;
 use roles_logic_sv2::mining_sv2::MESSAGE_TYPE_OPEN_STANDARD_MINING_CHANNEL;
 use roles_logic_sv2::mining_sv2::{OpenExtendedMiningChannel, OpenStandardMiningChannel};
 use roles_logic_sv2::parsers::{AnyMessage, CommonMessages, Mining, TemplateDistribution};
-use roles_logic_sv2::template_distribution_sv2::CoinbaseOutputConstraints;
-use roles_logic_sv2::template_distribution_sv2::MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS;
-use roles_logic_sv2::template_distribution_sv2::MESSAGE_TYPE_SUBMIT_SOLUTION;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -981,80 +978,19 @@ where
                             max_additional_sigops,
                         ) => {
                             debug!("Sv2ClientService received a trigger request for sending CoinbaseOutputConstraints");
-                            let tcp_client = this
-                                .template_distribution_tcp_client
-                                .read()
-                                .await
-                                .as_ref()
-                                .expect("template_distribution_tcp_client should be Some")
-                                .clone();
-                            let coinbase_output_constraints = AnyMessage::TemplateDistribution(
-                                TemplateDistribution::CoinbaseOutputConstraints(
-                                    CoinbaseOutputConstraints {
-                                        coinbase_output_max_additional_size: max_additional_size,
-                                        coinbase_output_max_additional_sigops: max_additional_sigops,
-                                    },
-                                ),
-                            );
-                            let result = tcp_client
-                                .io
-                                .send_message(
-                                    coinbase_output_constraints,
-                                    MESSAGE_TYPE_COINBASE_OUTPUT_CONSTRAINTS,
-                                )
-                                .await;
-                            match result {
-                                Ok(_) => {
-                                    debug!("Successfully set CoinbaseOutputConstraints");
-                                    this.config
-                                        .template_distribution_config
-                                        .as_mut()
-                                        .expect("template_distribution_config should be Some")
-                                        .coinbase_output_constraints =
-                                        (max_additional_size, max_additional_sigops);
-                                    Ok(ResponseFromSv2Client::Ok)
-                                }
-                                Err(e) => Err(e.into()),
-                            }
+                            this.template_distribution_handler.set_coinbase_output_constraints(max_additional_size, max_additional_sigops).await
                         }
                         RequestToSv2TemplateDistributionClientService::TransactionDataNeeded(
                             _template_id,
                         ) => {
                             debug!("Sv2ClientService received a trigger request for sending RequestTransactionData");
-                            todo!()
+                            this.template_distribution_handler.transaction_data_needed(_template_id).await
                         }
                         RequestToSv2TemplateDistributionClientService::SubmitSolution(
                             submit_solution,
                         ) => {
                             debug!("Sv2ClientService received a trigger request for sending SubmitSolution");
-                            if !this
-                                .is_connected(Protocol::TemplateDistributionProtocol)
-                                .await
-                            {
-                                return Err(RequestToSv2ClientError::IsNotConnected);
-                            }
-
-                            let tcp_client = this
-                                .template_distribution_tcp_client
-                                .read()
-                                .await
-                                .as_ref()
-                                .expect("template_distribution_tcp_client should be Some")
-                                .clone();
-                            let submit_solution = AnyMessage::TemplateDistribution(
-                                TemplateDistribution::SubmitSolution(submit_solution),
-                            );
-                            let result = tcp_client
-                                .io
-                                .send_message(submit_solution, MESSAGE_TYPE_SUBMIT_SOLUTION)
-                                .await;
-                            match result {
-                                Ok(_) => {
-                                    debug!("Successfully sent SubmitSolution");
-                                    Ok(ResponseFromSv2Client::Ok)
-                                }
-                                Err(e) => Err(e.into()),
-                            }
+                            this.template_distribution_handler.submit_solution(submit_solution).await
                         }
                     }
                 }
@@ -1073,6 +1009,94 @@ where
                         }
                     }
                 }
+                RequestToSv2Client::SendMessageToMiningServer(message) => {
+                    if this.config.mining_config.is_none()
+                        || std::any::TypeId::of::<M>()
+                            == std::any::TypeId::of::<NullSv2MiningClientHandler>()
+                    {
+                        return Err(RequestToSv2ClientError::UnsupportedProtocol {
+                            protocol: Protocol::MiningProtocol,
+                        });
+                    }
+
+                    if this.mining_tcp_client.read().await.is_none() {
+                        return Err(RequestToSv2ClientError::IsNotConnected);
+                    }
+
+                    let tcp_client = this
+                        .mining_tcp_client
+                        .read()
+                        .await
+                        .as_ref()
+                        .expect("mining_tcp_client should be Some")
+                        .clone();
+
+                    match tcp_client
+                        .io
+                        .send_message(AnyMessage::Mining(message.0), message.1)
+                        .await
+                    {
+                        Ok(_) => {
+                            debug!("Successfully sent message to mining server");
+                            return Ok(ResponseFromSv2Client::Ok);
+                        }
+                        Err(e) => Err(e.into()),
+                    }
+                }
+                RequestToSv2Client::SendMessageToTemplateDistributionServer(message) => {
+                    if this.config.template_distribution_config.is_none()
+                        || std::any::TypeId::of::<T>()
+                            == std::any::TypeId::of::<NullSv2TemplateDistributionClientHandler>()
+                    {
+                        return Err(RequestToSv2ClientError::UnsupportedProtocol {
+                            protocol: Protocol::TemplateDistributionProtocol,
+                        });
+                    }
+
+                    if this.template_distribution_tcp_client.read().await.is_none() {
+                        return Err(RequestToSv2ClientError::IsNotConnected);
+                    }
+
+                    let tcp_client = this
+                        .template_distribution_tcp_client
+                        .read()
+                        .await
+                        .as_ref()
+                        .expect("template_distribution_tcp_client should be Some")
+                        .clone();
+
+                    match tcp_client
+                        .io
+                        .send_message(AnyMessage::TemplateDistribution(message.0), message.1)
+                        .await
+                    {
+                        Ok(_) => {
+                            debug!("Successfully sent message to template distribution server");
+                            return Ok(ResponseFromSv2Client::Ok);
+                        }
+                        Err(e) => Err(e.into()),
+                    }
+                } // RequestToSv2Client::SendMessageToJobDeclarationServer(message) => {
+                  //     if this.config.job_declaration_config.is_none() || std::any::TypeId::of::<J>() == std::any::TypeId::of::<NullSv2JobDeclarationClientHandler>() {
+                  //         return Err(RequestToSv2ClientError::UnsupportedProtocol {
+                  //             protocol: Protocol::JobDeclarationProtocol,
+                  //         });
+                  //     }
+
+                  //     if this.job_declaration_tcp_client.read().await.is_none() {
+                  //         return Err(RequestToSv2ClientError::IsNotConnected);
+                  //     }
+
+                  //     let tcp_client = this.job_declaration_tcp_client.read().await.as_ref().expect("job_declaration_tcp_client should be Some").clone();
+
+                  //     match tcp_client.io.send_message(AnyMessage::JobDeclaration(message.0), message.1).await {
+                  //         Ok(_) => {
+                  //             debug!("Successfully sent message to job declaration server");
+                  //             return Ok(ResponseFromSv2Client::Ok);
+                  //         },
+                  //         Err(e) => Err(e.into()),
+                  //     }
+                  // }
             };
 
             // allows for recursive chaining of requests

--- a/src/client/service/mod.rs
+++ b/src/client/service/mod.rs
@@ -475,7 +475,7 @@ where
                 message_result = tcp_client.io.recv_message() => {
                     match message_result {
                         Ok((message, _)) => {
-                            if let Err(e) = self.call(RequestToSv2Client::Message(message)).await {
+                            if let Err(e) = self.call(RequestToSv2Client::IncomingMessage(message)).await {
                                 // this is a protection from attacks where a server sends a message that it knows the client cannot handle
                                 // we simply log the error and ignore the message, without shutting down the client
                                 error!("Error handling message: {:?}, message will be ignored", e);
@@ -631,7 +631,7 @@ where
                         this.initiate_connection(protocol, 0).await
                     }
                 },
-                RequestToSv2Client::Message(sv2_message) => {
+                RequestToSv2Client::IncomingMessage(sv2_message) => {
                     match sv2_message {
                         AnyMessage::Common(common) => match common {
                             CommonMessages::SetupConnection(_) => {

--- a/src/client/service/request.rs
+++ b/src/client/service/request.rs
@@ -12,7 +12,7 @@ pub enum RequestToSv2Client<'a> {
     SetupConnectionTrigger(Protocol, u32), // protocol, flags
     /// Some Sv2 message addressed to the client.
     /// Could belong to any subprotocol.
-    Message(AnyMessage<'a>),
+    IncomingMessage(AnyMessage<'a>),
     MiningTrigger(RequestToSv2MiningClientService),
     TemplateDistributionTrigger(RequestToSv2TemplateDistributionClientService<'a>),
     /// The request is boxed to break the recursive type definition between RequestToSv2Client and RequestToSv2Server.

--- a/src/client/service/request.rs
+++ b/src/client/service/request.rs
@@ -3,7 +3,7 @@ use crate::client::service::subprotocols::template_distribution::request::Reques
 use crate::server::service::request::RequestToSv2Server;
 use crate::Sv2MessageIoError;
 use roles_logic_sv2::common_messages_sv2::Protocol;
-use roles_logic_sv2::parsers::AnyMessage;
+use roles_logic_sv2::parsers::{AnyMessage, Mining, TemplateDistribution};
 
 /// The request type for the [`crate::client::service::Sv2ClientService`] service.
 #[derive(Debug, Clone)]
@@ -15,8 +15,10 @@ pub enum RequestToSv2Client<'a> {
     IncomingMessage(AnyMessage<'a>),
     MiningTrigger(RequestToSv2MiningClientService),
     TemplateDistributionTrigger(RequestToSv2TemplateDistributionClientService<'a>),
-    /// The request is boxed to break the recursive type definition between RequestToSv2Client and RequestToSv2Server.
     SendRequestToSiblingServerService(Box<RequestToSv2Server<'a>>),
+    SendMessageToMiningServer(Box<(Mining<'a>, u8)>), // message, message_type
+    SendMessageToTemplateDistributionServer(Box<(TemplateDistribution<'a>, u8)>),
+    // SendMessageToJobDeclarationServer(Box<(JobDeclaration<'a>, u8)>),
 }
 
 /// The error type for the [`crate::client::service::Sv2ClientService`] service.

--- a/src/client/service/response.rs
+++ b/src/client/service/response.rs
@@ -1,10 +1,8 @@
 use crate::client::service::request::RequestToSv2Client;
-use roles_logic_sv2::parsers::AnyMessage;
 
 /// The response type for the tower service [`crate::client::service::Sv2ClientService`].
 #[derive(Debug)]
 pub enum ResponseFromSv2Client<'a> {
-    SendToServer(Box<AnyMessage<'a>>),
     TriggerNewRequest(Box<RequestToSv2Client<'a>>),
     Ok,
 }

--- a/src/server/service/client.rs
+++ b/src/server/service/client.rs
@@ -1,5 +1,6 @@
 use crate::server::service::connection::Sv2ConnectionClient;
 use crate::Sv2MessageIo;
+use roles_logic_sv2::parsers::AnyMessage;
 use std::time::Instant;
 
 /// Representation of a Client of a Sv2 Server, to be:
@@ -37,4 +38,11 @@ impl Sv2ServerServiceClient {
             .as_secs()
             > inactivity_limit_secs
     }
+}
+
+/// An ordered sequence of Sv2 messages, to be delivered to a specific client.
+#[derive(Debug, Clone)]
+pub struct Sv2MessagesToClient<'a> {
+    pub client_id: u32,
+    pub messages: Vec<(AnyMessage<'a>, u8)>,
 }

--- a/src/server/service/mod.rs
+++ b/src/server/service/mod.rs
@@ -1,11 +1,10 @@
 use crate::client::service::sibling::Sv2SiblingServerServiceIo;
-use crate::server::service::client::Sv2ServerServiceClient;
+use crate::server::service::client::{Sv2MessagesToClient, Sv2ServerServiceClient};
 use crate::server::service::config::Sv2ServerServiceConfig;
 use crate::server::service::connection::Sv2ConnectionClient;
 use crate::server::service::error::Sv2ServerServiceError;
 use crate::server::service::request::{RequestToSv2Server, RequestToSv2ServerError};
 use crate::server::service::response::ResponseFromSv2Server;
-use crate::server::service::response::Sv2MessageToClient;
 use crate::server::service::sibling::Sv2SiblingClientServiceIo;
 use crate::server::service::subprotocols::mining::handler::NullSv2MiningServerHandler;
 use crate::server::service::subprotocols::mining::handler::Sv2MiningServerHandler;
@@ -414,12 +413,15 @@ where
                     .expect("failed to encode string"),
             };
 
-            let response = ResponseFromSv2Server::SendReplyToClient(Box::new(Sv2MessageToClient {
-                client_id,
-                message: setup_connection_error.into(),
-                message_type:
-                    roles_logic_sv2::common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
-            }));
+            let response = ResponseFromSv2Server::TriggerNewRequest(Box::new(
+                RequestToSv2Server::SendMessagesToClient(Box::new(Sv2MessagesToClient {
+                    client_id,
+                    messages: vec![(
+                        setup_connection_error.into(),
+                        roles_logic_sv2::common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
+                    )],
+                })),
+            ));
             return Ok(response);
         }
 
@@ -435,12 +437,16 @@ where
                     .try_into()
                     .expect("failed to encode string"),
             };
-            let response = ResponseFromSv2Server::SendReplyToClient(Box::new(Sv2MessageToClient {
-                client_id,
-                message: setup_connection_error.into(),
-                message_type:
-                    roles_logic_sv2::common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
-            }));
+
+            let response = ResponseFromSv2Server::TriggerNewRequest(Box::new(
+                RequestToSv2Server::SendMessagesToClient(Box::new(Sv2MessagesToClient {
+                    client_id,
+                    messages: vec![(
+                        setup_connection_error.into(),
+                        roles_logic_sv2::common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
+                    )],
+                })),
+            ));
             return Ok(response);
         }
 
@@ -482,12 +488,15 @@ where
                     .expect("failed to encode string"),
             };
 
-            let response = ResponseFromSv2Server::SendReplyToClient(Box::new(Sv2MessageToClient {
-                client_id,
-                message: setup_connection_error.into(),
-                message_type:
-                    roles_logic_sv2::common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
-            }));
+            let response = ResponseFromSv2Server::TriggerNewRequest(Box::new(
+                RequestToSv2Server::SendMessagesToClient(Box::new(Sv2MessagesToClient {
+                    client_id,
+                    messages: vec![(
+                        setup_connection_error.into(),
+                        roles_logic_sv2::common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
+                    )],
+                })),
+            ));
 
             if !Self::has_null_handler(Protocol::MiningProtocol) {
                 self.mining_handler.add_client(client_id, req.flags).await;
@@ -539,12 +548,15 @@ where
             flags: setup_connection_success_flags,
         };
 
-        let response = ResponseFromSv2Server::SendReplyToClient(Box::new(Sv2MessageToClient {
-            client_id,
-            message: setup_connection_success.into(),
-            message_type:
-                roles_logic_sv2::common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
-        }));
+        let response = ResponseFromSv2Server::TriggerNewRequest(Box::new(
+            RequestToSv2Server::SendMessagesToClient(Box::new(Sv2MessagesToClient {
+                client_id,
+                messages: vec![(
+                    setup_connection_success.into(),
+                    roles_logic_sv2::common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+                )],
+            })),
+        ));
 
         Ok(response)
     }
@@ -838,38 +850,74 @@ where
                         }
                     }
                 }
-            };
+                RequestToSv2Server::SendMessagesToClient(sv2_messages_to_client) => {
+                    debug!("Sv2ServerService received a SendMessagesToClient request");
 
-            if let Ok(ResponseFromSv2Server::SendReplyToClient(sv2_message_to_client)) =
-                response.clone()
-            {
-                let client_id = sv2_message_to_client.client_id;
+                    let client_id = sv2_messages_to_client.client_id;
 
-                // Get the client's IO from the map
-                let io = {
-                    let clients = this.clients.read().await;
-                    if let Some(client) = clients.get(&client_id) {
-                        let client = client.read().await;
-                        client.io.clone()
-                    } else {
-                        tracing::error!(
-                            "client {} not found when trying to send response",
-                            client_id
-                        );
-                        return Err(RequestToSv2ServerError::FailedToSendResponseToClient);
+                    // Get the client's IO from the map
+                    let io = {
+                        let clients = this.clients.read().await;
+                        if let Some(client) = clients.get(&client_id) {
+                            let client = client.read().await;
+                            client.io.clone()
+                        } else {
+                            error!("Client not found in Sv2ServerService");
+                            return Err(RequestToSv2ServerError::FailedToSendResponseToClient);
+                        }
+                    };
+
+                    let messages = sv2_messages_to_client.messages;
+
+                    for (message, message_type) in messages {
+                        match io.send_message(message, message_type).await {
+                            Ok(_) => {
+                                continue;
+                            }
+                            Err(_) => {
+                                return Err(RequestToSv2ServerError::FailedToSendResponseToClient)
+                            }
+                        }
                     }
-                };
 
-                let message = sv2_message_to_client.message.clone();
-                let message_type = sv2_message_to_client.message_type;
-
-                match io.send_message(message, message_type).await {
-                    Ok(_) => {
-                        return Ok(ResponseFromSv2Server::Ok);
-                    }
-                    Err(_) => return Err(RequestToSv2ServerError::FailedToSendResponseToClient),
+                    return Ok(ResponseFromSv2Server::Ok);
                 }
-            }
+                RequestToSv2Server::SendMessagesToClients(sv2_messages_to_clients) => {
+                    debug!("Sv2ServerService received a SendMessagesToClients request");
+
+                    // iterate over each client and send the messages to them
+                    for sv2_messages_to_client in sv2_messages_to_clients.as_ref() {
+                        let client_id = sv2_messages_to_client.client_id;
+
+                        // Get the client's IO from the map
+                        let io = {
+                            let clients = this.clients.read().await;
+                            if let Some(client) = clients.get(&client_id) {
+                                let client = client.read().await;
+                                client.io.clone()
+                            } else {
+                                error!("Client not found in Sv2ServerService");
+                                return Err(RequestToSv2ServerError::FailedToSendResponseToClient);
+                            }
+                        };
+
+                        for (message, message_type) in sv2_messages_to_client.messages.clone() {
+                            match io.send_message(message, message_type).await {
+                                Ok(_) => {
+                                    continue;
+                                }
+                                Err(_) => {
+                                    return Err(
+                                        RequestToSv2ServerError::FailedToSendResponseToClient,
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    return Ok(ResponseFromSv2Server::Ok);
+                }
+            };
 
             // allow for recursive chaining of requests
             if let Ok(ResponseFromSv2Server::TriggerNewRequest(req)) = response {

--- a/src/server/service/request.rs
+++ b/src/server/service/request.rs
@@ -2,7 +2,7 @@ use roles_logic_sv2::common_messages_sv2::Protocol;
 use roles_logic_sv2::parsers::AnyMessage;
 
 use crate::client::service::request::RequestToSv2Client;
-use crate::server::service::response::Sv2MessageToClient;
+use crate::server::service::client::Sv2MessagesToClient;
 use crate::server::service::subprotocols::mining::request::RequestToSv2MiningServer;
 
 /// The request type for the [`crate::server::service::Sv2ServerService`] service.
@@ -18,6 +18,10 @@ pub enum RequestToSv2Server<'a> {
     // TemplateDistributionTrigger(RequestToSv2TemplateDistributionServer<'a>),
     /// The request is boxed to break the recursive type definition between RequestToSv2Client and RequestToSv2Server.
     SendRequestToSiblingClientService(Box<RequestToSv2Client<'a>>),
+    /// Send ordered sequence of Sv2 messages to a specific client.
+    SendMessagesToClient(Box<Sv2MessagesToClient<'a>>),
+    /// Send ordered sequences of Sv2 messages to different clients.
+    SendMessagesToClients(Box<Vec<Sv2MessagesToClient<'a>>>),
 }
 
 /// A Sv2 message addressed to the server, to be used as the request type of [`crate::server::service::Sv2ServerService`].
@@ -41,7 +45,6 @@ pub enum RequestToSv2ServerError {
     UnsupportedProtocol { protocol: Protocol },
     FailedToSendRequestToSiblingClientService,
     NoSiblingClientService,
-    Reply(Box<Sv2MessageToClient<'static>>),
     MiningHandlerError(String),
     TemplateDistributionHandlerError(String),
     JobDeclarationHandlerError(String),

--- a/src/server/service/request.rs
+++ b/src/server/service/request.rs
@@ -10,7 +10,7 @@ use crate::server::service::subprotocols::mining::request::RequestToSv2MiningSer
 pub enum RequestToSv2Server<'a> {
     /// Some Sv2 message addressed to the server.
     /// Could belong to any subprotocol.
-    Message(Sv2MessageToServer<'a>),
+    IncomingMessage(Sv2MessageToServer<'a>),
     /// Some trigger for the mining subprotocol service
     MiningTrigger(RequestToSv2MiningServer<'a>),
     // todo:

--- a/src/server/service/response.rs
+++ b/src/server/service/response.rs
@@ -1,19 +1,8 @@
-use roles_logic_sv2::parsers::AnyMessage;
-
 use crate::server::service::request::RequestToSv2Server;
-/// A reply containing a Sv2 message, to be delivered back to the client.
-#[derive(Debug, Clone)]
-pub struct Sv2MessageToClient<'a> {
-    pub client_id: u32,
-    pub message: AnyMessage<'a>,
-    pub message_type: u8,
-}
 
 /// The Response type for the tower service [`crate::server::service::Sv2ServerService`].
 #[derive(Debug, Clone)]
 pub enum ResponseFromSv2Server<'a> {
-    // triggers the service to send a reply to the client
-    SendReplyToClient(Box<Sv2MessageToClient<'a>>),
     TriggerNewRequest(Box<RequestToSv2Server<'a>>),
     Ok,
 }


### PR DESCRIPTION
unifies `ResponseFromSv2Client` and `ResponseFromSv2Client` so that both only have two variants:

```rust
pub enum ResponseFromSv2Client<'a> {
    TriggerNewRequest(Box<RequestToSv2Client<'a>>),
    Ok,
}
```

```rust
pub enum ResponseFromSv2Client<'a> {
    TriggerNewRequest(Box<RequestToSv2Client<'a>>),
    Ok,
}
```

in order to send messages, the service needs to do a `TriggerNewRequest` with an appropriate request variant