### PR TITLE
cleanup trigger terminology

### DIFF
--- a/examples/mining-client-cpu-miner/src/client.rs
+++ b/examples/mining-client-cpu-miner/src/client.rs
@@ -6,7 +6,7 @@ use tower_stratum::client::service::config::Sv2ClientServiceConfig;
 use tower_stratum::client::service::config::Sv2ClientServiceMiningConfig;
 use tower_stratum::client::service::request::RequestToSv2Client;
 use tower_stratum::client::service::response::ResponseFromSv2Client;
-use tower_stratum::client::service::subprotocols::mining::request::RequestToSv2MiningClientService;
+use tower_stratum::client::service::subprotocols::mining::trigger::MiningClientTrigger;
 use tower_stratum::client::service::subprotocols::template_distribution::handler::NullSv2TemplateDistributionClientHandler;
 use tower_stratum::tower::{Service, ServiceExt};
 use tracing::info;
@@ -73,7 +73,7 @@ impl MyMiningClient {
                 let open_standard_mining_channel_response = self
                     .sv2_client_service
                     .call(RequestToSv2Client::MiningTrigger(
-                        RequestToSv2MiningClientService::OpenStandardMiningChannel(
+                        MiningClientTrigger::OpenStandardMiningChannel(
                             0, // todo
                             self.user_identity.clone(),
                             10.0,              // todo
@@ -96,7 +96,7 @@ impl MyMiningClient {
                 let open_extended_mining_channel_response = self
                     .sv2_client_service
                     .call(RequestToSv2Client::MiningTrigger(
-                        RequestToSv2MiningClientService::OpenExtendedMiningChannel(
+                        MiningClientTrigger::OpenExtendedMiningChannel(
                             0, // todo
                             self.user_identity.clone(),
                             10.0,              // todo

--- a/examples/sibling-io-communication/src/main.rs
+++ b/examples/sibling-io-communication/src/main.rs
@@ -6,7 +6,7 @@ use tower_stratum::{
     client::service::{
         Sv2ClientService, request::RequestToSv2Client,
         subprotocols::mining::handler::NullSv2MiningClientHandler,
-        subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService,
+        subprotocols::template_distribution::trigger::TemplateDistributionClientTrigger,
     },
     server::service::Sv2ServerService,
     tower::Service,
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
     // This step is necessary to start receiving new templates.
     client_service
         .call(RequestToSv2Client::TemplateDistributionTrigger(
-            RequestToSv2TemplateDistributionClientService::SetCoinbaseOutputConstraints(
+            TemplateDistributionClientTrigger::SetCoinbaseOutputConstraints(
                 config
                     .client_config
                     .template_distribution_config

--- a/examples/sibling-io-communication/src/template_distribution_handler.rs
+++ b/examples/sibling-io-communication/src/template_distribution_handler.rs
@@ -9,7 +9,7 @@ use tower_stratum::client::service::request::{RequestToSv2Client, RequestToSv2Cl
 use tower_stratum::client::service::response::ResponseFromSv2Client;
 use tower_stratum::client::service::subprotocols::template_distribution::handler::Sv2TemplateDistributionClientHandler;
 use tower_stratum::server::service::request::RequestToSv2Server;
-use tower_stratum::server::service::subprotocols::mining::request::RequestToSv2MiningServer;
+use tower_stratum::server::service::subprotocols::mining::trigger::MiningServerTrigger;
 use tracing::info;
 #[derive(Debug, Clone, Default)]
 pub struct MyTemplateDistributionHandler {
@@ -43,7 +43,7 @@ impl Sv2TemplateDistributionClientHandler for MyTemplateDistributionHandler {
 
         let response = ResponseFromSv2Client::TriggerNewRequest(Box::new(
             RequestToSv2Client::SendRequestToSiblingServerService(Box::new(
-                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::NewTemplate(template)),
+                RequestToSv2Server::MiningTrigger(MiningServerTrigger::NewTemplate(template)),
             )),
         ));
         Ok(response)
@@ -58,7 +58,7 @@ impl Sv2TemplateDistributionClientHandler for MyTemplateDistributionHandler {
         // Similar to `handle_new_template`, this forwards the new previous hash to the MiningServer.
         let response = ResponseFromSv2Client::TriggerNewRequest(Box::new(
             RequestToSv2Client::SendRequestToSiblingServerService(Box::new(
-                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::SetNewPrevHash(
+                RequestToSv2Server::MiningTrigger(MiningServerTrigger::SetNewPrevHash(
                     prev_hash,
                 )),
             )),

--- a/examples/sibling-io-communication/src/template_distribution_handler.rs
+++ b/examples/sibling-io-communication/src/template_distribution_handler.rs
@@ -58,9 +58,7 @@ impl Sv2TemplateDistributionClientHandler for MyTemplateDistributionHandler {
         // Similar to `handle_new_template`, this forwards the new previous hash to the MiningServer.
         let response = ResponseFromSv2Client::TriggerNewRequest(Box::new(
             RequestToSv2Client::SendRequestToSiblingServerService(Box::new(
-                RequestToSv2Server::MiningTrigger(MiningServerTrigger::SetNewPrevHash(
-                    prev_hash,
-                )),
+                RequestToSv2Server::MiningTrigger(MiningServerTrigger::SetNewPrevHash(prev_hash)),
             )),
         ));
         Ok(response)

--- a/examples/template-distribution-client/src/client.rs
+++ b/examples/template-distribution-client/src/client.rs
@@ -8,7 +8,7 @@ use tower_stratum::client::service::config::Sv2ClientServiceTemplateDistribution
 use tower_stratum::client::service::request::RequestToSv2Client;
 use tower_stratum::client::service::response::ResponseFromSv2Client;
 use tower_stratum::client::service::subprotocols::mining::handler::NullSv2MiningClientHandler;
-use tower_stratum::client::service::subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService;
+use tower_stratum::client::service::subprotocols::template_distribution::trigger::TemplateDistributionClientTrigger;
 use tracing::info;
 
 pub struct MyTemplateDistributionClient {
@@ -73,7 +73,7 @@ impl MyTemplateDistributionClient {
         let set_coinbase_output_constraints_response = self
             .sv2_client_service
             .call(RequestToSv2Client::TemplateDistributionTrigger(
-                RequestToSv2TemplateDistributionClientService::SetCoinbaseOutputConstraints(
+                TemplateDistributionClientTrigger::SetCoinbaseOutputConstraints(
                     self.coinbase_output_max_additional_size,
                     self.coinbase_output_max_additional_sigops,
                 ),

--- a/src/client/service/mod.rs
+++ b/src/client/service/mod.rs
@@ -1130,7 +1130,7 @@ mod tests {
     use crate::server::service::request::RequestToSv2ServerError;
     use crate::server::service::response::ResponseFromSv2Server;
     use crate::server::service::subprotocols::mining::handler::Sv2MiningServerHandler;
-    use crate::server::service::subprotocols::mining::request::RequestToSv2MiningServer;
+    use crate::server::service::subprotocols::mining::trigger::MiningServerTrigger;
     use crate::server::service::Sv2ServerService;
     use integration_tests_sv2::interceptor::MessageDirection;
     use integration_tests_sv2::start_sniffer;
@@ -1340,7 +1340,7 @@ mod tests {
         ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
             let response = ResponseFromSv2Client::TriggerNewRequest(Box::new(
                 RequestToSv2Client::SendRequestToSiblingServerService(Box::new(
-                    RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::NewTemplate(
+                    RequestToSv2Server::MiningTrigger(MiningServerTrigger::NewTemplate(
                         template.into_static(),
                     )),
                 )),
@@ -1354,7 +1354,7 @@ mod tests {
         ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
             let response = ResponseFromSv2Client::TriggerNewRequest(Box::new(
                 RequestToSv2Client::SendRequestToSiblingServerService(Box::new(
-                    RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::SetNewPrevHash(
+                    RequestToSv2Server::MiningTrigger(MiningServerTrigger::SetNewPrevHash(
                         prev_hash.into_static(),
                     )),
                 )),
@@ -1931,7 +1931,7 @@ mod tests {
         let new_template_response = client_service
             .call(RequestToSv2Client::SendRequestToSiblingServerService(
                 Box::new(RequestToSv2Server::MiningTrigger(
-                    RequestToSv2MiningServer::NewTemplate(new_template),
+                    MiningServerTrigger::NewTemplate(new_template),
                 )),
             ))
             .await;
@@ -1955,7 +1955,7 @@ mod tests {
         let new_prev_hash_response = client_service
             .call(RequestToSv2Client::SendRequestToSiblingServerService(
                 Box::new(RequestToSv2Server::MiningTrigger(
-                    RequestToSv2MiningServer::SetNewPrevHash(new_prev_hash),
+                    MiningServerTrigger::SetNewPrevHash(new_prev_hash),
                 )),
             ))
             .await
@@ -2063,7 +2063,7 @@ mod tests {
         let new_template_response = client_service
             .call(RequestToSv2Client::SendRequestToSiblingServerService(
                 Box::new(RequestToSv2Server::MiningTrigger(
-                    RequestToSv2MiningServer::NewTemplate(new_template),
+                    MiningServerTrigger::NewTemplate(new_template),
                 )),
             ))
             .await;

--- a/src/client/service/mod.rs
+++ b/src/client/service/mod.rs
@@ -5,10 +5,10 @@ use crate::client::service::response::ResponseFromSv2Client;
 use crate::client::service::sibling::Sv2SiblingServerServiceIo;
 use crate::client::service::subprotocols::mining::handler::NullSv2MiningClientHandler;
 use crate::client::service::subprotocols::mining::handler::Sv2MiningClientHandler;
-use crate::client::service::subprotocols::mining::request::RequestToSv2MiningClientService;
+use crate::client::service::subprotocols::mining::trigger::MiningClientTrigger;
 use crate::client::service::subprotocols::template_distribution::handler::NullSv2TemplateDistributionClientHandler;
 use crate::client::service::subprotocols::template_distribution::handler::Sv2TemplateDistributionClientHandler;
-use crate::client::service::subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService;
+use crate::client::service::subprotocols::template_distribution::trigger::TemplateDistributionClientTrigger;
 use crate::client::tcp::encrypted::Sv2EncryptedTcpClient;
 use roles_logic_sv2::common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION;
 use roles_logic_sv2::common_messages_sv2::{Protocol, SetupConnection};
@@ -849,7 +849,7 @@ where
                         return Err(RequestToSv2ClientError::IsNotConnected);
                     }
                     match request {
-                        RequestToSv2MiningClientService::OpenStandardMiningChannel(
+                        MiningClientTrigger::OpenStandardMiningChannel(
                             request_id,
                             user_identity,
                             nominal_hash_rate,
@@ -900,7 +900,7 @@ where
                                 Err(e) => Err(e.into()),
                             }
                         }
-                        RequestToSv2MiningClientService::OpenExtendedMiningChannel(
+                        MiningClientTrigger::OpenExtendedMiningChannel(
                             request_id,
                             user_identity,
                             nominal_hash_rate,
@@ -973,20 +973,20 @@ where
                         return Err(RequestToSv2ClientError::IsNotConnected);
                     }
                     match request {
-                        RequestToSv2TemplateDistributionClientService::SetCoinbaseOutputConstraints(
+                        TemplateDistributionClientTrigger::SetCoinbaseOutputConstraints(
                             max_additional_size,
                             max_additional_sigops,
                         ) => {
                             debug!("Sv2ClientService received a trigger request for sending CoinbaseOutputConstraints");
                             this.template_distribution_handler.set_coinbase_output_constraints(max_additional_size, max_additional_sigops).await
                         }
-                        RequestToSv2TemplateDistributionClientService::TransactionDataNeeded(
+                        TemplateDistributionClientTrigger::TransactionDataNeeded(
                             _template_id,
                         ) => {
                             debug!("Sv2ClientService received a trigger request for sending RequestTransactionData");
                             this.template_distribution_handler.transaction_data_needed(_template_id).await
                         }
-                        RequestToSv2TemplateDistributionClientService::SubmitSolution(
+                        TemplateDistributionClientTrigger::SubmitSolution(
                             submit_solution,
                         ) => {
                             debug!("Sv2ClientService received a trigger request for sending SubmitSolution");
@@ -1120,7 +1120,7 @@ mod tests {
     use crate::client::service::subprotocols::mining::handler::Sv2MiningClientHandler;
     use crate::client::service::subprotocols::template_distribution::handler::NullSv2TemplateDistributionClientHandler;
     use crate::client::service::subprotocols::template_distribution::handler::Sv2TemplateDistributionClientHandler;
-    use crate::client::service::subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService;
+    use crate::client::service::subprotocols::template_distribution::trigger::TemplateDistributionClientTrigger;
     use crate::client::service::RequestToSv2ClientError;
     use crate::client::service::Sv2ClientService;
     use crate::server::service::config::Sv2ServerServiceConfig;
@@ -1894,7 +1894,7 @@ mod tests {
         // Trigger the Template Provider to set coinbase output constraints.
         client_service
             .call(RequestToSv2Client::TemplateDistributionTrigger(
-                RequestToSv2TemplateDistributionClientService::SetCoinbaseOutputConstraints(
+                TemplateDistributionClientTrigger::SetCoinbaseOutputConstraints(
                     template_distribution_config.coinbase_output_constraints.0,
                     template_distribution_config.coinbase_output_constraints.1,
                 ),
@@ -2083,7 +2083,7 @@ mod tests {
     async fn sv2_client_service_submit_solution() {
         use crate::client::service::request::RequestToSv2Client;
         use crate::client::service::response::ResponseFromSv2Client;
-        use crate::client::service::subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService;
+        use crate::client::service::subprotocols::template_distribution::trigger::TemplateDistributionClientTrigger;
         use roles_logic_sv2::common_messages_sv2::Protocol;
         use roles_logic_sv2::template_distribution_sv2::SubmitSolution;
 
@@ -2142,7 +2142,7 @@ mod tests {
         };
 
         let submit_solution_request = RequestToSv2Client::TemplateDistributionTrigger(
-            RequestToSv2TemplateDistributionClientService::SubmitSolution(submit_solution),
+            TemplateDistributionClientTrigger::SubmitSolution(submit_solution),
         );
 
         let response = sv2_client_service.call(submit_solution_request).await;

--- a/src/client/service/request.rs
+++ b/src/client/service/request.rs
@@ -1,5 +1,5 @@
-use crate::client::service::subprotocols::mining::request::RequestToSv2MiningClientService;
-use crate::client::service::subprotocols::template_distribution::request::RequestToSv2TemplateDistributionClientService;
+use crate::client::service::subprotocols::mining::trigger::MiningClientTrigger;
+use crate::client::service::subprotocols::template_distribution::trigger::TemplateDistributionClientTrigger;
 use crate::server::service::request::RequestToSv2Server;
 use crate::Sv2MessageIoError;
 use roles_logic_sv2::common_messages_sv2::Protocol;
@@ -13,8 +13,8 @@ pub enum RequestToSv2Client<'a> {
     /// Some Sv2 message addressed to the client.
     /// Could belong to any subprotocol.
     IncomingMessage(AnyMessage<'a>),
-    MiningTrigger(RequestToSv2MiningClientService),
-    TemplateDistributionTrigger(RequestToSv2TemplateDistributionClientService<'a>),
+    MiningTrigger(MiningClientTrigger),
+    TemplateDistributionTrigger(TemplateDistributionClientTrigger<'a>),
     SendRequestToSiblingServerService(Box<RequestToSv2Server<'a>>),
     SendMessageToMiningServer(Box<(Mining<'a>, u8)>), // message, message_type
     SendMessageToTemplateDistributionServer(Box<(TemplateDistribution<'a>, u8)>),

--- a/src/client/service/subprotocols/mining/mod.rs
+++ b/src/client/service/subprotocols/mining/mod.rs
@@ -1,2 +1,2 @@
 pub mod handler;
-pub mod request;
+pub mod trigger;

--- a/src/client/service/subprotocols/mining/trigger.rs
+++ b/src/client/service/subprotocols/mining/trigger.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone)]
-pub enum RequestToSv2MiningClientService {
+pub enum MiningClientTrigger {
     OpenStandardMiningChannel(u32, String, f32, Vec<u8>),
     OpenExtendedMiningChannel(u32, String, f32, Vec<u8>, u16),
 }

--- a/src/client/service/subprotocols/template_distribution/mod.rs
+++ b/src/client/service/subprotocols/template_distribution/mod.rs
@@ -1,2 +1,2 @@
 pub mod handler;
-pub mod request;
+pub mod trigger;

--- a/src/client/service/subprotocols/template_distribution/trigger.rs
+++ b/src/client/service/subprotocols/template_distribution/trigger.rs
@@ -2,7 +2,7 @@ use roles_logic_sv2::template_distribution_sv2::SubmitSolution;
 
 /// Requests to the Client Service that are specific to the Template Distribution protocol
 #[derive(Debug, Clone)]
-pub enum RequestToSv2TemplateDistributionClientService<'a> {
+pub enum TemplateDistributionClientTrigger<'a> {
     SetCoinbaseOutputConstraints(u32, u16),
     TransactionDataNeeded(u64),
     SubmitSolution(SubmitSolution<'a>),

--- a/src/server/service/mod.rs
+++ b/src/server/service/mod.rs
@@ -10,7 +10,7 @@ use crate::server::service::response::ResponseFromSv2Server;
 use crate::server::service::sibling::Sv2SiblingClientServiceIo;
 use crate::server::service::subprotocols::mining::handler::NullSv2MiningServerHandler;
 use crate::server::service::subprotocols::mining::handler::Sv2MiningServerHandler;
-use crate::server::service::subprotocols::mining::request::RequestToSv2MiningServer;
+use crate::server::service::subprotocols::mining::trigger::MiningServerTrigger;
 use crate::server::tcp::encrypted::start_encrypted_tcp_server;
 use crate::server::ClientIdGenerator;
 use roles_logic_sv2::common_messages_sv2::{
@@ -824,11 +824,11 @@ where
                     }
                 }
                 RequestToSv2Server::MiningTrigger(req) => match req {
-                    RequestToSv2MiningServer::NewTemplate(new_template) => {
+                    MiningServerTrigger::NewTemplate(new_template) => {
                         debug!("Sv2ServerService received a NewTemplate message via external mining trigger");
                         this.mining_handler.on_new_template(new_template).await
                     }
-                    RequestToSv2MiningServer::SetNewPrevHash(set_new_prev_hash) => {
+                    MiningServerTrigger::SetNewPrevHash(set_new_prev_hash) => {
                         debug!("Sv2ServerService received a SetNewPrevHash message via external mining trigger");
                         this.mining_handler
                             .on_set_new_prev_hash(set_new_prev_hash)

--- a/src/server/service/request.rs
+++ b/src/server/service/request.rs
@@ -3,7 +3,7 @@ use roles_logic_sv2::parsers::AnyMessage;
 
 use crate::client::service::request::RequestToSv2Client;
 use crate::server::service::client::Sv2MessagesToClient;
-use crate::server::service::subprotocols::mining::request::RequestToSv2MiningServer;
+use crate::server::service::subprotocols::mining::trigger::MiningServerTrigger;
 
 /// The request type for the [`crate::server::service::Sv2ServerService`] service.
 #[derive(Debug, Clone)]
@@ -12,7 +12,7 @@ pub enum RequestToSv2Server<'a> {
     /// Could belong to any subprotocol.
     IncomingMessage(Sv2MessageToServer<'a>),
     /// Some trigger for the mining subprotocol service
-    MiningTrigger(RequestToSv2MiningServer<'a>),
+    MiningTrigger(MiningServerTrigger<'a>),
     // todo:
     // JobDeclarationTrigger(RequestToSv2JobDeclarationServer<'a>),
     // TemplateDistributionTrigger(RequestToSv2TemplateDistributionServer<'a>),

--- a/src/server/service/subprotocols/mining/mod.rs
+++ b/src/server/service/subprotocols/mining/mod.rs
@@ -1,2 +1,2 @@
 pub mod handler;
-pub mod request;
+pub mod trigger;

--- a/src/server/service/subprotocols/mining/trigger.rs
+++ b/src/server/service/subprotocols/mining/trigger.rs
@@ -2,7 +2,7 @@ use roles_logic_sv2::template_distribution_sv2::{NewTemplate, SetNewPrevHash};
 
 /// Requests to the Server Service that are specific to the Mining subprotocol.
 #[derive(Debug, Clone)]
-pub enum RequestToSv2MiningServer<'a> {
+pub enum MiningServerTrigger<'a> {
     NewTemplate(NewTemplate<'a>),
     SetNewPrevHash(SetNewPrevHash<'a>),
 }


### PR DESCRIPTION
we were using `Request*` terminology for subprotocol handlers, which is a bit conceptually misleading

here we unify everything related to subprotocol handlers to be called "triggers", and leave the `Request*` terminology only for the actual implementors of the `tower::Service` trait (namely `Sv2ServerService` and `Sv2ClientService`)

to be merged after #28